### PR TITLE
ci: harden the release path before Ack publishes

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,0 +1,102 @@
+name: Set up a checksum-verified Flutter SDK
+description: >-
+  Downloads an official Linux Flutter archive and verifies its SHA-256 checksum
+  against .github/flutter-releases.json before it reaches PATH. Every workflow
+  installs Flutter through this action, so no workflow runs an unverified
+  installer script.
+
+inputs:
+  flutter-version:
+    description: >-
+      Flutter version to install. It must have an entry in
+      .github/flutter-releases.json. Defaults to the version that .fvmrc pins.
+    required: false
+    default: ''
+
+outputs:
+  flutter-version:
+    description: The Flutter version that this action installed.
+    value: ${{ steps.release.outputs.flutter-version }}
+  dart-version:
+    description: The Dart version that ships inside the installed Flutter SDK.
+    value: ${{ steps.release.outputs.dart-version }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve the pinned release
+      id: release
+      shell: bash
+      env:
+        REQUESTED_VERSION: ${{ inputs.flutter-version }}
+      run: |
+        set -euo pipefail
+        version="$REQUESTED_VERSION"
+        if [ -z "$version" ]; then
+          version="$(jq -r '.flutter' .fvmrc)"
+        fi
+        release="$(jq -r --arg v "$version" '.releases[$v] // empty' \
+          .github/flutter-releases.json)"
+        if [ -z "$release" ]; then
+          echo "Flutter $version has no entry in .github/flutter-releases.json." >&2
+          echo "Add its checksum before a workflow installs it." >&2
+          exit 1
+        fi
+        {
+          printf 'flutter-version=%s\n' "$version"
+          printf 'dart-version=%s\n' "$(printf '%s' "$release" | jq -r '.dart')"
+          printf 'sha256=%s\n' "$(printf '%s' "$release" | jq -r '.sha256')"
+        } >> "$GITHUB_OUTPUT"
+
+    # The archive is cached, not the extracted SDK, so the checksum is verified
+    # on every run. A cache hit only skips the download. The path carries the
+    # version, because one job may install two versions.
+    - name: Restore the cached archive
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ${{ runner.temp }}/flutter-archive/${{ steps.release.outputs.flutter-version }}
+        key: flutter-linux-${{ steps.release.outputs.flutter-version }}-${{ steps.release.outputs.sha256 }}
+
+    - name: Install the Flutter SDK
+      shell: bash
+      env:
+        FLUTTER_VERSION: ${{ steps.release.outputs.flutter-version }}
+        FLUTTER_ARCHIVE_SHA256: ${{ steps.release.outputs.sha256 }}
+        FLUTTER_ARCHIVE: ${{ runner.temp }}/flutter-archive/${{ steps.release.outputs.flutter-version }}/flutter.tar.xz
+      run: |
+        set -euo pipefail
+        archive_url="https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}-stable.tar.xz"
+        mkdir -p "$(dirname "$FLUTTER_ARCHIVE")"
+        if [ ! -f "$FLUTTER_ARCHIVE" ]; then
+          curl --fail --location --silent --show-error \
+            --proto '=https' --tlsv1.2 \
+            --output "$FLUTTER_ARCHIVE" "$archive_url"
+        fi
+        printf '%s  %s\n' "$FLUTTER_ARCHIVE_SHA256" "$FLUTTER_ARCHIVE" \
+          | sha256sum --check
+        # One job may install two Flutter versions, so each SDK gets its own
+        # directory and the newest entry in PATH wins.
+        install_root="$RUNNER_TEMP/flutter-$FLUTTER_VERSION"
+        rm -rf "$install_root"
+        mkdir -p "$install_root"
+        tar --extract --xz --file "$FLUTTER_ARCHIVE" \
+          --directory "$install_root"
+        printf '%s\n' "$install_root/flutter/bin" >> "$GITHUB_PATH"
+
+    - name: Confirm the installed SDK versions
+      shell: bash
+      env:
+        EXPECTED_FLUTTER: ${{ steps.release.outputs.flutter-version }}
+        EXPECTED_DART: ${{ steps.release.outputs.dart-version }}
+      run: |
+        set -euo pipefail
+        flutter --version
+        dart --version
+        flutter --version | grep -q "Flutter $EXPECTED_FLUTTER " || {
+          echo "PATH does not expose Flutter $EXPECTED_FLUTTER." >&2
+          exit 1
+        }
+        dart --version | grep -q "Dart SDK version: $EXPECTED_DART " || {
+          echo "PATH does not expose Dart $EXPECTED_DART." >&2
+          exit 1
+        }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,8 @@
 - `example`: sample usage.
 
 ## Environment and setup
-- Required SDKs: Dart `>=3.9.0 <4.0.0`, Flutter `>=3.16.0` (see `/pubspec.yaml`).
+- Required SDKs: Dart `>=3.9.0 <4.0.0`, Flutter `>=3.35.0` (see `/pubspec.yaml`).
+- CI pins Flutter to the version in `/.fvmrc`. Add a new version to `/.github/flutter-releases.json` with its checksum before a workflow may install it.
 - Use from repo root:
   1. `dart pub get`
   2. `dart run melos bootstrap`
@@ -37,7 +38,9 @@
 - Do not hand-edit generated `*.g.dart` files unless the repo pattern for that area explicitly requires it; prefer rerunning build/golden tooling.
 
 ## CI and release notes
-- CI is defined in `/.github/workflows/ci.yml` and delegates to `btwld/dart-actions/.github/workflows/ci.yml@main` with DCM enabled.
+- CI is defined in `/.github/workflows/ci.yml`. It runs in this repository, installs the pinned Flutter SDK through `/.github/actions/setup-flutter`, and pins every external action to a commit SHA.
+- `/.github/workflows/preflight.yml` holds the release checks: minimum-SDK lanes, JSON Schema Draft-7 batch validation, API comparison against the published baseline, deterministic regeneration, and publish dry runs.
+- `/.github/workflows/release.yml` verifies the tag with `dart scripts/verify_release_tag.dart` and reruns the preflight before it publishes.
 - Conventional Commits are expected for commit messages.
 - Publishing/versioning flows are documented in `/PUBLISHING.md` (`dart run melos version`, `dart run melos publish`).
 

--- a/.github/flutter-releases.json
+++ b/.github/flutter-releases.json
@@ -1,0 +1,13 @@
+{
+  "description": "Flutter releases that this repository's workflows may install. Each entry pins the SHA-256 checksum of the official Linux archive and the Dart SDK that ships inside it. Copy both values from https://storage.googleapis.com/flutter_infra_release/releases/releases_linux.json before adding a version.",
+  "releases": {
+    "3.35.0": {
+      "dart": "3.9.0",
+      "sha256": "ff2d9474d768fdb61c1b8d6b76fd4eb98235c271e68b10abf41bd9fb41bc273d"
+    },
+    "3.41.2": {
+      "dart": "3.11.0",
+      "sha256": "4a04f8a6152986d14fc137ffaf98106ca743c0f9ab66f1bc2f20ee84eb573e5c"
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+  # No `branches:` filter. A stacked pull request targets its parent
+  # branch, not main, and would otherwise run no checks at all.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,36 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
-    # The dart-actions repo moved from the btwld org to conceptadev. The REST
-    # API follows that rename redirect, but the Actions reusable-workflow
-    # resolver does not, so the old path fails startup with "workflow was not
-    # found". Keep this owner in sync with the repo's actual location.
-    uses: conceptadev/dart-actions/.github/workflows/ci.yml@main
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-    with:
-      flutter-version: "3.41.2"
-      run-dcm: true
+    # This job used to call conceptadev/dart-actions/.github/workflows/ci.yml@main.
+    # That reference was mutable and its FVM step piped an unverified installer
+    # into a shell, so every run could execute code that nobody reviewed here.
+    # The checks now live in this repository and pin every dependency.
+    name: Run tests for all packages
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up the pinned Flutter SDK
+        uses: ./.github/actions/setup-flutter
+
+      - name: Resolve workspace dependencies
+        run: dart pub get
+
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze and test every package
+        run: dart run melos run ci --no-select

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,34 +2,44 @@ name: Documentation
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [main]
     paths:
       - 'docs/**'
       - 'docs.json'
       - 'llms.txt'
   pull_request:
-    branches: [ "main" ]
+    branches: [main]
     paths:
       - 'docs/**'
       - 'docs.json'
       - 'llms.txt'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    name: validate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
-      
-      - name: Install docs.page CLI
-        run: npm install -g @docs.page/cli
 
       - name: Verify llms.txt sources
         run: |
+          set -euo pipefail
           test -s llms.txt || {
             echo "llms.txt is missing or empty."
             exit 1
@@ -42,19 +52,11 @@ jobs:
             echo "The docs homepage must link to the generated docs.page llms.txt export."
             exit 1
           }
-      
+
+      # Pin the CLI version. An unpinned `npm install -g @docs.page/cli` would
+      # execute whatever the registry serves at run time, which is the
+      # mutable-dependency problem that the other workflows removed.
       - name: Validate documentation
-        run: npx @docs.page/cli check
-      
-  notify:
-    needs: validate
-    if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify docs.page update
-        run: |
-          echo "Documentation has been updated and is now available at https://concepta.dev/ack"
-          # You could add additional notification steps here, such as:
-          # - Sending a Slack message
-          # - Creating a GitHub issue
-          # - Sending an email notification
+        env:
+          DOCS_PAGE_CLI_VERSION: '2.0.0'
+        run: npx --yes "@docs.page/cli@$DOCS_PAGE_CLI_VERSION" check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,8 +7,9 @@ on:
       - 'docs/**'
       - 'docs.json'
       - 'llms.txt'
+  # No `branches:` filter. A stacked pull request targets its parent
+  # branch, not main, and would otherwise run no checks at all.
   pull_request:
-    branches: [main]
     paths:
       - 'docs/**'
       - 'docs.json'

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,224 @@
+name: Release preflight
+
+# Every check that must hold before Ack may publish. The release workflow runs
+# this same file from the tag, so the tag gets the exact checks that the pull
+# request got.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preflight-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # The published release that every public API is compared against. Raise it
+  # after each published version. `dart_apitool` compares the declared version
+  # against the change severity, so a breaking change requires a major bump.
+  API_BASELINE_VERSION: '1.1.0'
+  # The lowest SDK versions that packages/*/pubspec.yaml accept.
+  MINIMUM_DART_VERSION: '3.9.0'
+  MINIMUM_FLUTTER_VERSION: '3.35.0'
+
+jobs:
+  minimum-dart-sdk:
+    name: Minimum Dart SDK
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up the pinned Flutter SDK
+        uses: ./.github/actions/setup-flutter
+
+      - name: Resolve workspace dependencies
+        run: dart pub get
+
+      # The complete workspace cannot resolve on the minimum SDK, because
+      # flutter_test pins an older test_api than ack_generator's analyzer floor
+      # allows. The pure-Dart members still must resolve, so they get their own
+      # staged workspace.
+      - name: Stage the pure-Dart workspace
+        run: dart scripts/stage_min_sdk_workspace.dart "${{ runner.temp }}/min-dart"
+
+      - name: Set up the minimum Dart SDK
+        uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1
+        with:
+          sdk: ${{ env.MINIMUM_DART_VERSION }}
+
+      - name: Confirm the minimum Dart SDK is active
+        run: |
+          set -euo pipefail
+          dart --version
+          dart --version 2>&1 \
+            | grep -q "Dart SDK version: $MINIMUM_DART_VERSION " || {
+            echo "PATH does not expose Dart $MINIMUM_DART_VERSION." >&2
+            exit 1
+          }
+
+      - name: Resolve the staged workspace
+        working-directory: ${{ runner.temp }}/min-dart
+        run: dart pub get
+
+      # The staged workspace is a plain directory, not a git checkout, so the
+      # release-tooling tests under /test cannot run here. They run in the CI
+      # workflow at the pinned SDK. This lane proves that the published
+      # packages analyze and pass on the SDK floor.
+      - name: Analyze and test the staged workspace
+        working-directory: ${{ runner.temp }}/min-dart
+        run: |
+          set -euo pipefail
+          dart analyze scripts test --fatal-infos
+          for pubspec in $(find . -mindepth 2 -name pubspec.yaml -not -path './.dart_tool/*' | sort); do
+            package="$(dirname "$pubspec")"
+            echo "::group::$package"
+            (cd "$package" && dart analyze . --fatal-infos)
+            if [ -d "$package/test" ]; then
+              (cd "$package" && dart test)
+            fi
+            echo "::endgroup::"
+          done
+
+  minimum-flutter-sdk:
+    name: Minimum Flutter SDK
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up the pinned Flutter SDK
+        uses: ./.github/actions/setup-flutter
+
+      - name: Resolve workspace dependencies
+        run: dart pub get
+
+      - name: Stage the Flutter adapter outside the workspace
+        run: |
+          dart scripts/stage_package.dart ack_firebase_ai \
+            "${{ runner.temp }}/min-flutter" --local-deps
+
+      - name: Set up the minimum Flutter SDK
+        uses: ./.github/actions/setup-flutter
+        with:
+          flutter-version: ${{ env.MINIMUM_FLUTTER_VERSION }}
+
+      - name: Analyze and test the staged adapter
+        working-directory: ${{ runner.temp }}/min-flutter/packages/ack_firebase_ai
+        run: |
+          set -euo pipefail
+          flutter pub get
+          flutter analyze --fatal-infos
+          flutter test
+
+  json-schema-draft7:
+    name: JSON Schema Draft-7 batch validation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: tools/npm-shrinkwrap.json
+
+      - name: Install the validator dependencies
+        working-directory: tools
+        run: npm ci
+
+      - name: Validate every reference fixture against Draft-7
+        working-directory: tools
+        run: |
+          node jsonschema-validator.js validate-batch \
+            --input test-fixtures/reference-config.json
+
+  api-compatibility:
+    name: API compatibility
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up the pinned Flutter SDK
+        uses: ./.github/actions/setup-flutter
+
+      - name: Resolve workspace dependencies
+        run: dart pub get
+
+      - name: Compare every package against the published baseline
+        run: dart scripts/api_check.dart "$API_BASELINE_VERSION"
+
+  deterministic-generation:
+    name: Deterministic generation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up the pinned Flutter SDK
+        uses: ./.github/actions/setup-flutter
+
+      - name: Resolve workspace dependencies
+        run: dart pub get
+
+      # `.ack.dart` holds the generated models and `.ack.g.dart` holds the JSON
+      # mapping. Both are generated, so a clean rebuild must reproduce them.
+      # The `*.g.dart` glob below also matches `*.ack.g.dart`.
+      - name: Delete the committed generator output
+        run: |
+          set -euo pipefail
+          git ls-files -z -- '*.ack.dart' '*.g.dart' \
+            | xargs -0 --no-run-if-empty rm --
+
+      - name: Regenerate from a clean tree
+        run: dart run melos run build --no-select
+
+      - name: Require the regenerated output to match the repository
+        run: |
+          set -euo pipefail
+          git add --intent-to-add .
+          git diff --exit-code
+
+  publish-dry-run:
+    name: Publish dry run
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up the pinned Flutter SDK
+        uses: ./.github/actions/setup-flutter
+
+      - name: Resolve workspace dependencies
+        run: dart pub get
+
+      - name: Require every package to publish without warnings
+        run: dart scripts/publish_dry_run.dart

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -7,8 +7,9 @@ name: Release preflight
 on:
   push:
     branches: [main]
+  # No `branches:` filter. A stacked pull request targets its parent
+  # branch, not main, and would otherwise run no checks at all.
   pull_request:
-    branches: [main]
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -16,6 +16,7 @@ jobs:
   prepare:
     name: Prepare package list
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -41,10 +42,6 @@ jobs:
       fail-fast: false
       matrix:
         package: ${{ fromJson(needs.prepare.outputs.matrix) }}
-    env:
-      FLUTTER_VERSION: 3.41.2
-      FLUTTER_ARCHIVE_URL: https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.41.2-stable.tar.xz
-      FLUTTER_ARCHIVE_SHA256: 4a04f8a6152986d14fc137ffaf98106ca743c0f9ab66f1bc2f20ee84eb573e5c
 
     steps:
       - name: Checkout repository
@@ -52,51 +49,83 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Dart and provision pub.dev OIDC
-        uses: dart-lang/setup-dart@6afc89df92d6eb3834022f73cd65adc8cdfcb92d # v1
+      # `pub` performs the pub.dev OIDC exchange itself when the job grants
+      # `id-token: write`, so no extra action provisions credentials. Each
+      # package must also enable automated publishing on pub.dev for the
+      # `conceptadev/ack` repository. See PUBLISHING.md.
+      - name: Set up the pinned Flutter SDK
+        uses: ./.github/actions/setup-flutter
 
-      - name: Install checksum-verified Flutter SDK
+      - name: Choose the SDK executable for this package
+        id: sdk
         env:
-          FLUTTER_ARCHIVE: ${{ runner.temp }}/flutter.tar.xz
+          PUBSPEC: ${{ inputs.packages_folder_path }}/${{ matrix.package }}/pubspec.yaml
         run: |
           set -euo pipefail
-          curl --fail --location --silent --show-error \
-            --proto '=https' --tlsv1.2 \
-            --output "$FLUTTER_ARCHIVE" "$FLUTTER_ARCHIVE_URL"
-          printf '%s  %s\n' "$FLUTTER_ARCHIVE_SHA256" "$FLUTTER_ARCHIVE" \
-            | sha256sum --check
-          tar --extract --xz --file "$FLUTTER_ARCHIVE" \
-            --directory "$RUNNER_TEMP"
-          printf '%s\n' "$RUNNER_TEMP/flutter/bin" >> "$GITHUB_PATH"
-
-      - name: Verify pinned SDK versions
-        run: |
-          set -euo pipefail
-          test "$(jq -r '.flutter' .fvmrc)" = "$FLUTTER_VERSION"
-          flutter --version
-          dart --version
-
-      - name: Install package dependencies
-        working-directory: ${{ inputs.packages_folder_path }}/${{ matrix.package }}
-        run: |
-          set -euo pipefail
-          if grep -q "sdk: flutter" pubspec.yaml; then
-            flutter pub get
+          if grep -q "sdk: flutter" "$PUBSPEC"; then
+            printf 'executable=flutter\n' >> "$GITHUB_OUTPUT"
           else
-            dart pub get
+            printf 'executable=dart\n' >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run package tests
+      - name: Resolve workspace dependencies
+        run: dart pub get
+
+      # Workspace resolution replaces every `ack: ^1.2.0` constraint with the
+      # sibling directory, so a workspace test never proves that a pub.dev
+      # consumer can resolve this release. The staged copy leaves the workspace
+      # and therefore resolves the versions that the previous stage published.
+      - name: Stage the package outside the workspace
+        id: stage
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: |
+          set -euo pipefail
+          staged="$(dart scripts/stage_package.dart "$PACKAGE" \
+            "$RUNNER_TEMP/staged")"
+          printf 'directory=%s\n' "$staged" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve the staged package against pub.dev
+        working-directory: ${{ steps.stage.outputs.directory }}
+        env:
+          SDK: ${{ steps.sdk.outputs.executable }}
+        run: |
+          set -euo pipefail
+          # pub.dev needs a moment to serve a version that the preceding stage
+          # published, so a first failure is not yet a release failure.
+          for attempt in 1 2 3 4 5; do
+            if "$SDK" pub get; then
+              exit 0
+            fi
+            echo "Resolution attempt $attempt failed; retrying in 30 seconds."
+            sleep 30
+          done
+          echo "The staged package cannot resolve its hosted dependencies." >&2
+          exit 1
+
+      # Analysis is the strongest check the staged copy can run. The
+      # `ack_generator` end-to-end tests build fixtures that path-depend on
+      # sibling packages, and staging deliberately leaves those siblings behind.
+      # The tests therefore run in the workspace copy below.
+      - name: Analyze the staged package against pub.dev
+        working-directory: ${{ steps.stage.outputs.directory }}
+        env:
+          SDK: ${{ steps.sdk.outputs.executable }}
+        run: |
+          set -euo pipefail
+          "$SDK" analyze . --fatal-infos
+
+      - name: Run the package tests
         working-directory: ${{ inputs.packages_folder_path }}/${{ matrix.package }}
+        env:
+          SDK: ${{ steps.sdk.outputs.executable }}
         run: |
           set -euo pipefail
           if [ ! -d test ]; then
             echo "No test folder found; skipping tests."
-          elif grep -q "sdk: flutter" pubspec.yaml; then
-            flutter test
-          else
-            dart test
+            exit 0
           fi
+          "$SDK" test
 
       - name: Restore the reviewed package tree
         working-directory: ${{ inputs.packages_folder_path }}/${{ matrix.package }}
@@ -110,9 +139,14 @@ jobs:
           fi
 
       - name: Validate package publication
-        working-directory: ${{ inputs.packages_folder_path }}/${{ matrix.package }}
-        run: dart pub publish --dry-run
+        env:
+          PACKAGE: ${{ matrix.package }}
+        run: dart scripts/publish_dry_run.dart "$PACKAGE"
 
       - name: Publish package with pub.dev OIDC
         working-directory: ${{ inputs.packages_folder_path }}/${{ matrix.package }}
-        run: dart pub publish --force
+        env:
+          SDK: ${{ steps.sdk.outputs.executable }}
+        run: |
+          set -euo pipefail
+          "$SDK" pub publish --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,55 @@ on:
       # Pre-release tags, e.g. v1.2.3-beta.1 / v1.2.3-rc.1
       - 'v[0-9]*.[0-9]*.[0-9]*-*'
 
+permissions:
+  contents: read
+
 jobs:
+  verify-tag:
+    name: Verify the release tag
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      # The full history lets the check prove that the tag sits on main.
+      - name: Checkout the tagged commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # A full checkout already carries origin/main. The refresh keeps the
+      # check current when the tag lands moments after a merge, and the
+      # verification step reports a missing ref on its own.
+      - name: Refresh the release branch
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main \
+            || echo "Could not refresh origin/main; using the checked-out refs."
+
+      - name: Set up the pinned Flutter SDK
+        uses: ./.github/actions/setup-flutter
+
+      - name: Resolve workspace dependencies
+        run: dart pub get
+
+      # A tag is the only trigger of this workflow, so the tag must prove that
+      # it points at reviewed code and that every package agrees on the version.
+      - name: Require a releasable tag
+        run: |
+          dart scripts/verify_release_tag.dart "$GITHUB_REF_NAME" \
+            --commit="$GITHUB_SHA" --main-ref=origin/main
+
+  preflight:
+    name: Preflight
+    needs: verify-tag
+    permissions:
+      contents: read
+    uses: ./.github/workflows/preflight.yml
+
   publish-foundations:
     name: Publish foundation packages
+    needs: preflight
     uses: ./.github/workflows/publish-packages.yml
     permissions:
       contents: read

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -18,9 +18,20 @@ Before creating a release:
 
 1. Ensure all changes are committed and pushed to the `main` branch
 2. Verify that all tests pass by running `dart run melos run test` (include `dart run melos run validate-jsonschema` and `dart run melos run test:gen` for full coverage)
-3. Check that the documentation is up to date across the repo and docs site
-4. Decide on the new version number following [Semantic Versioning](https://semver.org/) and apply it consistently to every publishable package (`ack`, `ack_annotations`, `ack_generator`, `ack_firebase_ai`, `ack_json_schema_builder`)
-5. Ensure package CHANGELOG entries are finalized before tagging. If you want a link-only entry for a version, you can run `dart scripts/update_release_changelog.dart <version> [tag]` after `dart run melos version`.
+3. Confirm that the `Release preflight` workflow is green on the merge commit. Run its checks locally with:
+
+   ```bash
+   dart scripts/stage_min_sdk_workspace.dart /tmp/ack-min-dart
+   dart scripts/stage_package.dart ack_firebase_ai /tmp/ack-min-flutter --local-deps
+   dart run melos run validate-jsonschema:batch
+   dart scripts/api_check.dart 1.1.0
+   dart run melos run build && git diff --exit-code
+   dart scripts/publish_dry_run.dart
+   ```
+
+4. Check that the documentation is up to date across the repo and docs site
+5. Decide on the new version number following [Semantic Versioning](https://semver.org/) and apply it consistently to every publishable package (`ack`, `ack_annotations`, `ack_generator`, `ack_firebase_ai`, `ack_json_schema_builder`)
+6. Ensure package CHANGELOG entries are finalized before tagging. If you want a link-only entry for a version, you can run `dart scripts/update_release_changelog.dart <version> [tag]` after `dart run melos version`.
 
 ### 2. Create a GitHub Release
 
@@ -66,19 +77,44 @@ This release introduces [brief description of major changes].
 
 When the `v*` tag is pushed, the GitHub Actions workflow will automatically:
 
-1. Test and publish the independent `ack` and `ack_annotations` foundation
+1. Verify the tag with `dart scripts/verify_release_tag.dart`. The tag commit
+   must be reachable from `main`, and the tagged version must match every
+   publishable `pubspec.yaml` version and every `CHANGELOG.md` heading.
+2. Rerun `.github/workflows/preflight.yml` on the tagged commit.
+3. Test and publish the independent `ack` and `ack_annotations` foundation
    packages.
-2. After both hosted versions are available, test and publish `ack_generator`.
-3. After the generator stage completes, test and publish
+4. After both hosted versions are available, test and publish `ack_generator`.
+5. After the generator stage completes, test and publish
    `ack_json_schema_builder` and `ack_firebase_ai`.
-4. Run `dart pub publish --dry-run` immediately before each package upload.
+6. Run `dart scripts/publish_dry_run.dart` immediately before each package
+   upload and require zero warnings.
 
-This staging is required for coordinated releases because workspace resolution
-uses local packages, while published consumers resolve the hosted versions. The
-local reusable workflow calls are deliberately sequential so each dependent
-package resolves the foundation version published by the preceding stage. Its
-external actions are commit-pinned, and its pinned Flutter archive is verified
-against a checked-in SHA-256 value before execution.
+Each publish stage first copies its package out of the workspace with
+`dart scripts/stage_package.dart`, then resolves and tests it there. Workspace
+resolution replaces every `ack: ^1.2.0` constraint with the local sibling
+directory, so only the staged copy proves that a pub.dev consumer can resolve
+the release. The stages are deliberately sequential, so each dependent package
+resolves the foundation version that the preceding stage published.
+
+Every external action is pinned to a commit SHA, and the Flutter SDK is
+installed only through `.github/actions/setup-flutter`, which verifies the
+archive against the SHA-256 value in `.github/flutter-releases.json`.
+`test/scripts/release_workflow_security_test.dart` enforces these rules.
+
+### pub.dev automated publishing
+
+`pub` exchanges the GitHub OIDC token for a pub.dev token by itself, so the
+publish job only grants `id-token: write`. Each of the five packages must also
+enable automated publishing on pub.dev before the first automated release:
+
+1. Open `https://pub.dev/packages/<package>/admin`.
+2. Enable **Automated publishing** from GitHub Actions.
+3. Set the repository to `conceptadev/ack`.
+4. Set the tag pattern to `v{{version}}`.
+5. Set the environment to `Production`, which matches the publish job.
+
+Confirm all five packages after any repository rename or owner change,
+because pub.dev stores the repository name, not its numeric id.
 
 The workflow does **not** modify versions or changelogs, and does **not** commit changes back to the repository.
 
@@ -107,17 +143,27 @@ git push --follow-tags
 
 ## Manual Publishing
 
-If you need to publish packages manually:
+Publishing runs only from a `v*` tag. The repository has no `melos run publish`
+or `melos run release` script, because a one-command publish would skip tag
+verification, the preflight, the `Production` environment gate, and the staged
+hosted-dependency proof.
+
+Publish by hand only when GitHub Actions is unavailable. Run every gate first,
+from a clean checkout of the tag:
 
 ```bash
-# Dry-run each package (validation only)
-for pkg in ack ack_annotations ack_generator ack_json_schema_builder ack_firebase_ai; do
-  (cd packages/$pkg && dart pub publish --dry-run) || exit 1
-done
+dart scripts/verify_release_tag.dart v<version>
+dart scripts/publish_dry_run.dart
+dart run melos run validate-jsonschema:batch
+dart scripts/api_check.dart <previous-version>
 
-# Actual publish (no dry-run)
-dart run melos run publish
+# Only then, one package at a time, in release order:
+#   ack, ack_annotations -> ack_generator -> ack_json_schema_builder, ack_firebase_ai
+(cd packages/<package> && dart pub publish)
 ```
+
+A manual upload uses your personal pub.dev credentials rather than the
+repository's OIDC identity. Prefer fixing the workflow.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -280,12 +280,12 @@ dart run melos run clean
 # Propose/apply version and changelog updates
 dart run melos version
 
-# Dry-run pub.dev validation for one package
-(cd packages/ack && dart pub publish --dry-run)
-
-# Publish all packages (no dry-run)
-dart run melos run publish
+# Dry-run pub.dev validation for every package, requiring zero warnings
+dart scripts/publish_dry_run.dart
 ```
+
+Publishing runs only from a `v*` tag through GitHub Actions. See
+[PUBLISHING.md](./PUBLISHING.md).
 
 ### Development tools
 

--- a/packages/ack_annotations/pubspec.yaml
+++ b/packages/ack_annotations/pubspec.yaml
@@ -12,4 +12,7 @@ dependencies:
   meta: ^1.15.0
 
 dev_dependencies:
+  # Every sibling package declares lints, so the shared analysis_options.yaml
+  # include also resolves when this package is analyzed outside the workspace.
+  lints: ^5.0.0
   test: ^1.25.15

--- a/packages/ack_annotations/test/ack_type_test.dart
+++ b/packages/ack_annotations/test/ack_type_test.dart
@@ -4,6 +4,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('public barrel exposes legacy AckType and modern AckInfer', () {
+    // ignore: deprecated_member_use_from_same_package
     const legacy = AckType(name: 'User');
     const modern = AckInfer(name: 'User');
     expect(legacy.name, 'User');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,13 +32,6 @@ melos:
   ide:
     intellij: false
 
-  bootstrap:
-    dependencies:
-      meta: ^1.15.0
-    dev_dependencies:
-      lints: ^5.0.0
-      test: ^1.25.15
-
   command:
     version:
       # Generate changelogs for the workspace
@@ -113,17 +106,10 @@ melos:
       packageFilters:
         dependsOn: build_runner
 
-    # Version and publish scripts
-    # Publishing helpers
-    publish:
-      run: dart run melos publish --no-dry-run --yes
-      description: Publish packages to pub.dev
-
-    release:
-      run: |
-        dart run melos version --yes
-        dart run melos publish --no-dry-run --yes
-      description: One-step version and publish
+    # There is deliberately no `publish` or `release` script. Publishing runs
+    # only from a `v*` tag through .github/workflows/release.yml, which
+    # verifies the tag, reruns the preflight, and uploads through pub.dev OIDC.
+    # See PUBLISHING.md.
 
     # ACK Generator specific test commands
     test:gen:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,12 @@ dependencies:
 
 dev_dependencies:
   melos: ^7.3.0
+  # Release tooling under /scripts reads and rewrites pubspecs.
+  path: ^1.9.0
   test: ^1.25.15
   very_good_analysis: ^9.0.0
+  yaml: ^3.1.2
+  yaml_edit: ^2.2.1
   # Shared lint config consumed by /analysis_options.yaml (workspace-wide).
   lints: ^5.0.0
   dart_code_metrics_presets: ^2.22.0

--- a/scripts/publish_dry_run.dart
+++ b/scripts/publish_dry_run.dart
@@ -1,0 +1,85 @@
+#!/usr/bin/env dart
+
+import 'dart:io';
+
+import 'src/staging.dart';
+import 'src/workspace_packages.dart';
+
+/// Runs `pub publish --dry-run` for every publishable Ack package and requires
+/// a clean result.
+///
+/// `pub` reports packaging problems as warnings, and a warning that reaches
+/// pub.dev cannot be withdrawn. The release therefore treats any warning as a
+/// failure.
+///
+/// Usage:
+/// `dart scripts/publish_dry_run.dart [package ...]`
+///
+/// With no arguments the script checks every publishable package.
+Future<void> main(List<String> args) async {
+  final packages = args.isEmpty ? publishableAckPackages : args;
+  final unknown = packages.where(
+    (package) => !publishableAckPackages.contains(package),
+  );
+  if (unknown.isNotEmpty) {
+    stderr.writeln(
+      'Unknown packages: ${unknown.join(', ')}. '
+      'Available packages: ${publishableAckPackages.join(', ')}',
+    );
+    exitCode = 64;
+
+    return;
+  }
+
+  final failures = <String>[];
+  for (final package in packages) {
+    stdout.writeln('Validating packages/$package ...');
+    final failure = await _dryRun(package);
+    if (failure != null) failures.add(failure);
+  }
+
+  if (failures.isEmpty) {
+    stdout.writeln('All ${packages.length} packages publish cleanly.');
+
+    return;
+  }
+
+  stderr.writeln('Publish validation failed:');
+  for (final failure in failures) {
+    stderr.writeln('  - $failure');
+  }
+  exitCode = 1;
+}
+
+/// Returns a failure description, or `null` when [package] is publishable.
+Future<String?> _dryRun(String package) async {
+  final directory = 'packages/$package';
+  // A Flutter package must resolve through the Flutter SDK, so its dry run
+  // goes through the `flutter` executable.
+  final executable =
+      requiresFlutter(File('$directory/pubspec.yaml').readAsStringSync())
+      ? 'flutter'
+      : 'dart';
+
+  final ProcessResult result;
+  try {
+    result = await Process.run(executable, [
+      'pub',
+      'publish',
+      '--dry-run',
+    ], workingDirectory: directory);
+  } on ProcessException catch (error) {
+    return '$package: could not run $executable pub publish: ${error.message}';
+  }
+
+  final output = '${result.stdout}${result.stderr}';
+  stdout.writeln(output);
+  if (result.exitCode != 0) {
+    return '$package: $executable pub publish exited with ${result.exitCode}';
+  }
+  if (!output.contains('Package has 0 warnings.')) {
+    return '$package: publish validation reported warnings';
+  }
+
+  return null;
+}

--- a/scripts/src/release_changelog.dart
+++ b/scripts/src/release_changelog.dart
@@ -44,6 +44,12 @@ ChangelogUpdate updateReleaseChangelog(
   return (content: updated, found: true, changed: updated != content);
 }
 
+/// Reports whether [content] declares a release heading for [version].
+///
+/// Prerelease headings such as `1.0.0-beta.1` do not match version `1.0.0`.
+bool hasVersionHeading(String content, {required String version}) =>
+    content.split('\n').any((line) => _isVersionHeading(line, version));
+
 bool _isVersionHeading(String line, String version) {
   final escapedVersion = RegExp.escape(version);
   final pattern = RegExp(

--- a/scripts/src/staging.dart
+++ b/scripts/src/staging.dart
@@ -1,0 +1,169 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:yaml/yaml.dart';
+import 'package:yaml_edit/yaml_edit.dart';
+
+/// Files that must never reach a staging directory.
+///
+/// `melos` writes path overrides into `pubspec_overrides.yaml`. A staged tree
+/// must resolve its Ack dependencies the way a pub.dev consumer does, so the
+/// override file stays behind.
+const _excludedFileNames = <String>{'pubspec_overrides.yaml'};
+
+/// Copies the tracked files under [paths] into [output].
+///
+/// Every file keeps its repository-relative path, so a staged package still
+/// finds sibling files such as the shared `analysis_options.yaml`. The copy
+/// reads the working tree, which lets a maintainer stage uncommitted work.
+Directory stageTrackedFiles(String output, {required List<String> paths}) {
+  final directory = Directory(output);
+  if (directory.existsSync()) directory.deleteSync(recursive: true);
+  directory.createSync(recursive: true);
+
+  for (final relativePath in trackedFiles(paths)) {
+    final source = File(relativePath);
+    // `git ls-files` also lists files that the working tree has deleted.
+    if (!source.existsSync()) continue;
+    if (_excludedFileNames.contains(p.basename(relativePath))) continue;
+
+    final target = File(p.join(output, relativePath));
+    target.parent.createSync(recursive: true);
+    source.copySync(target.path);
+  }
+
+  return directory;
+}
+
+/// Lists the repository-relative paths that git tracks under [paths].
+///
+/// `-z` makes git separate the paths with NUL and leave them unquoted, so the
+/// list stays exact for every path name that the repository can hold.
+List<String> trackedFiles(List<String> paths) {
+  final result = Process.runSync('git', ['ls-files', '-z', '--', ...paths]);
+  if (result.exitCode != 0) {
+    throw ProcessException(
+      'git',
+      ['ls-files', '--', ...paths],
+      '${result.stderr}',
+      result.exitCode,
+    );
+  }
+
+  return (result.stdout as String)
+      .split(String.fromCharCode(0))
+      .where((entry) => entry.isNotEmpty)
+      .toList();
+}
+
+/// Removes `resolution: workspace` from [pubspec].
+///
+/// Pub then resolves the staged package on its own and honours its published
+/// version constraints instead of the workspace sibling paths.
+String detachFromWorkspace(String pubspec) {
+  final editor = YamlEditor(pubspec);
+  if (_valueAt(editor, ['resolution']) == null) return pubspec;
+  editor.remove(['resolution']);
+
+  return editor.toString();
+}
+
+/// Points the [overrides] dependencies of [pubspec] at staged sibling paths.
+String overrideWithStagedPackages(
+  String pubspec,
+  Map<String, String> overrides,
+) {
+  if (overrides.isEmpty) return pubspec;
+
+  final editor = YamlEditor(pubspec);
+  if (_valueAt(editor, ['dependency_overrides']) == null) {
+    editor.update(['dependency_overrides'], <String, Object?>{});
+  }
+  for (final entry in overrides.entries) {
+    editor.update(
+      ['dependency_overrides', entry.key],
+      <String, Object?>{'path': entry.value},
+    );
+  }
+
+  return editor.toString();
+}
+
+/// Removes the [flutterMembers] workspace entries and the Flutter SDK
+/// constraint from a workspace root [pubspec].
+///
+/// The complete workspace cannot resolve on the minimum Dart SDK, because
+/// `flutter_test` pins an older `test_api` than the analyzer floor of
+/// `ack_generator` allows. Dropping the Flutter members produces a resolvable
+/// pure-Dart workspace that still covers every other package.
+String toPureDartWorkspace(
+  String pubspec, {
+  required Set<String> flutterMembers,
+}) {
+  final editor = YamlEditor(pubspec);
+  final members = _valueAt(editor, ['workspace']);
+  if (members is List) {
+    editor.update([
+      'workspace',
+    ], members.where((member) => !flutterMembers.contains(member)).toList());
+  }
+  if (_valueAt(editor, ['environment', 'flutter']) != null) {
+    editor.remove(['environment', 'flutter']);
+  }
+
+  return editor.toString();
+}
+
+/// Lists the workspace members that a workspace root [pubspec] declares.
+List<String> workspaceMembers(String pubspec) {
+  final document = loadYaml(pubspec);
+  if (document is! Map) return const [];
+  final members = document['workspace'];
+  if (members is! List) return const [];
+
+  return members.map((member) => '$member').toList();
+}
+
+/// Reports whether the package described by [pubspec] needs the Flutter SDK.
+bool requiresFlutter(String pubspec) {
+  final document = loadYaml(pubspec);
+  if (document is! Map) return false;
+  final environment = document['environment'];
+  if (environment is Map && environment.containsKey('flutter')) return true;
+  for (final section in const ['dependencies', 'dev_dependencies']) {
+    final dependencies = document[section];
+    if (dependencies is! Map) continue;
+    for (final dependency in dependencies.values) {
+      if (dependency is Map && dependency['sdk'] == 'flutter') return true;
+    }
+  }
+
+  return false;
+}
+
+/// Returns the names in [candidates] that [pubspec] depends on directly.
+List<String> directDependenciesAmong(String pubspec, List<String> candidates) {
+  final document = loadYaml(pubspec);
+  if (document is! Map) return const [];
+  final names = <String>{};
+  for (final section in const ['dependencies', 'dev_dependencies']) {
+    final dependencies = document[section];
+    if (dependencies is Map) {
+      names.addAll(dependencies.keys.map((key) => '$key'));
+    }
+  }
+
+  return candidates.where(names.contains).toList();
+}
+
+/// Reads the `version` field of [pubspec], or `null` when it declares none.
+String? readPubspecVersion(String pubspec) {
+  final document = loadYaml(pubspec);
+  if (document is! Map) return null;
+  final version = document['version'];
+
+  return version == null ? null : '$version';
+}
+
+Object? _valueAt(YamlEditor editor, List<String> path) =>
+    editor.parseAt(path, orElse: () => wrapAsYamlNode(null)).value;

--- a/scripts/stage_min_sdk_workspace.dart
+++ b/scripts/stage_min_sdk_workspace.dart
@@ -1,0 +1,66 @@
+#!/usr/bin/env dart
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'src/staging.dart';
+
+/// Copies the repository into a pure-Dart workspace that resolves on the
+/// minimum Dart SDK.
+///
+/// The complete workspace cannot resolve on Dart 3.9, because `flutter_test`
+/// pins `test_api 0.7.6` while the root `test` constraint and the Analyzer 10
+/// dependency of `ack_generator` require a newer `test_api`. Removing the
+/// Flutter workspace members leaves a resolvable workspace that still covers
+/// every pure-Dart package. The Flutter packages get their own staged lane
+/// through `scripts/stage_package.dart`.
+///
+/// Usage:
+/// `dart scripts/stage_min_sdk_workspace.dart <output-directory>`
+///
+/// The script prints the staged workspace root on success.
+void main(List<String> args) {
+  if (args.length != 1) {
+    stderr.writeln(
+      'Usage: dart scripts/stage_min_sdk_workspace.dart <output-directory>',
+    );
+    exitCode = 64;
+
+    return;
+  }
+
+  final output = args.single;
+  stageTrackedFiles(output, paths: const ['.']);
+
+  final root = File(p.join(output, 'pubspec.yaml'));
+  final flutterMembers = _flutterWorkspaceMembers(output, root);
+  root.writeAsStringSync(
+    toPureDartWorkspace(
+      root.readAsStringSync(),
+      flutterMembers: flutterMembers,
+    ),
+  );
+  // Removing the sources as well keeps the staged tree consistent: every
+  // remaining pubspec belongs to the staged workspace.
+  for (final member in flutterMembers) {
+    Directory(p.join(output, member)).deleteSync(recursive: true);
+  }
+
+  stdout
+    ..writeln('Removed Flutter workspace members: ${flutterMembers.join(', ')}')
+    ..writeln(output);
+}
+
+/// Returns the staged workspace members that need the Flutter SDK.
+Set<String> _flutterWorkspaceMembers(String output, File root) {
+  final members = workspaceMembers(root.readAsStringSync());
+
+  return members
+      .where(
+        (member) => requiresFlutter(
+          File(p.join(output, member, 'pubspec.yaml')).readAsStringSync(),
+        ),
+      )
+      .toSet();
+}

--- a/scripts/stage_package.dart
+++ b/scripts/stage_package.dart
@@ -1,0 +1,103 @@
+#!/usr/bin/env dart
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+import 'src/staging.dart';
+import 'src/workspace_packages.dart';
+
+/// Copies one Ack package out of the melos workspace so pub resolves it the
+/// way a pub.dev consumer does.
+///
+/// Workspace resolution replaces every `ack: ^1.2.0` constraint with the local
+/// sibling directory, so a workspace check never proves that the hosted
+/// versions resolve. A staged package drops `resolution: workspace` and
+/// therefore resolves its Ack dependencies from pub.dev.
+///
+/// Usage:
+/// `dart scripts/stage_package.dart <package> <output> [--local-deps]`
+///
+/// Options:
+///   --local-deps  Also stage the Ack packages that this package depends on,
+///                 and override the staged package to use them. Use this for a
+///                 minimum-SDK check of unpublished packages; omit it to prove
+///                 hosted resolution.
+///
+/// The script prints the staged package directory on success.
+void main(List<String> args) {
+  final positional = args.where((arg) => !arg.startsWith('--')).toList();
+  final useLocalDeps = args.contains('--local-deps');
+  final unknownOptions = args.where(
+    (arg) => arg.startsWith('--') && arg != '--local-deps',
+  );
+
+  if (positional.length != 2 || unknownOptions.isNotEmpty) {
+    stderr.writeln(
+      'Usage: dart scripts/stage_package.dart <package> <output-directory> '
+      '[--local-deps]',
+    );
+    exitCode = 64;
+
+    return;
+  }
+
+  final package = positional[0];
+  final output = positional[1];
+  if (!publishableAckPackages.contains(package)) {
+    stderr.writeln(
+      'Unknown package "$package". '
+      'Available packages: ${publishableAckPackages.join(', ')}',
+    );
+    exitCode = 64;
+
+    return;
+  }
+
+  final staged = useLocalDeps
+      ? _ackDependencyClosure(package)
+      : <String>{package};
+
+  stageTrackedFiles(
+    output,
+    paths: [
+      // Every package analysis_options.yaml includes the workspace root file.
+      'analysis_options.yaml',
+      for (final name in staged) 'packages/$name',
+    ],
+  );
+
+  for (final name in staged) {
+    final pubspec = File(p.join(output, 'packages', name, 'pubspec.yaml'));
+    final source = pubspec.readAsStringSync();
+    pubspec.writeAsStringSync(
+      overrideWithStagedPackages(detachFromWorkspace(source), {
+        for (final dependency in directDependenciesAmong(
+          source,
+          publishableAckPackages,
+        ))
+          if (staged.contains(dependency)) dependency: '../$dependency',
+      }),
+    );
+  }
+
+  stdout.writeln(p.join(output, 'packages', package));
+}
+
+/// Returns [package] together with every Ack package it depends on.
+Set<String> _ackDependencyClosure(String package) {
+  final closure = <String>{};
+  final pending = <String>[package];
+  while (pending.isNotEmpty) {
+    final name = pending.removeLast();
+    if (!closure.add(name)) continue;
+    pending.addAll(
+      directDependenciesAmong(
+        File('packages/$name/pubspec.yaml').readAsStringSync(),
+        publishableAckPackages,
+      ),
+    );
+  }
+
+  return closure;
+}

--- a/scripts/verify_release_tag.dart
+++ b/scripts/verify_release_tag.dart
@@ -1,0 +1,185 @@
+#!/usr/bin/env dart
+
+import 'dart:io';
+
+import 'src/release_changelog.dart';
+import 'src/staging.dart';
+import 'src/workspace_packages.dart';
+
+/// Verifies that a release tag may publish the packages in this checkout.
+///
+/// A tag is the only trigger of `.github/workflows/release.yml`, so the tag
+/// itself must prove three things before any upload:
+///
+/// 1. Its commit is reachable from `main`, which keeps unreviewed commits out
+///    of a release.
+/// 2. Every publishable package declares exactly the tagged version.
+/// 3. Every publishable changelog documents that version.
+///
+/// Usage:
+/// `dart scripts/verify_release_tag.dart <tag> [options]`
+///
+/// Options:
+///   `--main-ref=<ref>`  Ref that must contain the tag. Defaults to
+///                     `origin/main`.
+///   `--commit=<sha>`    Commit that the tag points at. Defaults to the
+///                     commit that `<tag>` resolves to in this checkout.
+///   --skip-ancestry   Skip the reachability check. Use it only when checking
+///                     a version before the tag exists.
+void main(List<String> args) {
+  final options = _Options.parse(args);
+  if (options == null) {
+    stderr.writeln(
+      'Usage: dart scripts/verify_release_tag.dart <tag> '
+      '[--main-ref=<ref>] [--commit=<sha>] [--skip-ancestry]',
+    );
+    exitCode = 64;
+
+    return;
+  }
+
+  final parsed = _versionFromTag(options.tag);
+  final failures = <String>[
+    ...?parsed.failure,
+    ...?_checkPackages(parsed.version),
+    if (!options.skipAncestry) ..._checkAncestry(options),
+  ];
+
+  if (failures.isEmpty) {
+    stdout.writeln('${options.tag} is releasable.');
+
+    return;
+  }
+
+  stderr.writeln('${options.tag} is not releasable:');
+  for (final failure in failures) {
+    stderr.writeln('  - $failure');
+  }
+  exitCode = 1;
+}
+
+/// Splits `v1.2.0` into its version, or reports why the tag is unusable.
+({String? version, List<String>? failure}) _versionFromTag(String tag) {
+  final match = RegExp(
+    r'^v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$',
+  ).firstMatch(tag);
+  if (match == null) {
+    return (
+      version: null,
+      failure: ['tag "$tag" is not a `v<major>.<minor>.<patch>` release tag'],
+    );
+  }
+
+  return (version: match.group(1)!, failure: null);
+}
+
+/// Checks that every publishable package and changelog states [version].
+List<String>? _checkPackages(String? version) {
+  if (version == null) return null;
+
+  final failures = <String>[];
+  for (final package in publishableAckPackages) {
+    final pubspecPath = 'packages/$package/pubspec.yaml';
+    final pubspec = File(pubspecPath);
+    if (!pubspec.existsSync()) {
+      failures.add('$pubspecPath is missing');
+      continue;
+    }
+
+    final declared = readPubspecVersion(pubspec.readAsStringSync());
+    if (declared != version) {
+      failures.add('$pubspecPath declares "$declared" instead of "$version"');
+    }
+
+    final changelogPath = 'packages/$package/CHANGELOG.md';
+    final changelog = File(changelogPath);
+    if (!changelog.existsSync()) {
+      failures.add('$changelogPath is missing');
+      continue;
+    }
+
+    if (!hasVersionHeading(changelog.readAsStringSync(), version: version)) {
+      failures.add('$changelogPath has no "## $version" heading');
+    }
+  }
+
+  return failures;
+}
+
+/// Checks that the tagged commit is reachable from the release branch.
+List<String> _checkAncestry(_Options options) {
+  final commit = options.commit ?? _revParse('${options.tag}^{commit}');
+  if (commit == null) {
+    return ['tag "${options.tag}" does not resolve to a commit'];
+  }
+
+  final mainCommit = _revParse('${options.mainRef}^{commit}');
+  if (mainCommit == null) {
+    return [
+      'ref "${options.mainRef}" is not available; '
+          'fetch it before verifying the tag',
+    ];
+  }
+
+  final ancestry = Process.runSync('git', [
+    'merge-base',
+    '--is-ancestor',
+    commit,
+    mainCommit,
+  ]);
+  if (ancestry.exitCode == 0) return const [];
+
+  return [
+    'commit $commit is not reachable from ${options.mainRef} ($mainCommit)',
+  ];
+}
+
+String? _revParse(String revision) {
+  final result = Process.runSync('git', ['rev-parse', '--verify', revision]);
+  if (result.exitCode != 0) return null;
+
+  return (result.stdout as String).trim();
+}
+
+class _Options {
+  const _Options({
+    required this.tag,
+    required this.mainRef,
+    required this.commit,
+    required this.skipAncestry,
+  });
+
+  final String tag;
+  final String mainRef;
+  final String? commit;
+  final bool skipAncestry;
+
+  static _Options? parse(List<String> args) {
+    final positional = <String>[];
+    var mainRef = 'origin/main';
+    String? commit;
+    var skipAncestry = false;
+
+    for (final arg in args) {
+      if (arg == '--skip-ancestry') {
+        skipAncestry = true;
+      } else if (arg.startsWith('--main-ref=')) {
+        mainRef = arg.substring('--main-ref='.length);
+      } else if (arg.startsWith('--commit=')) {
+        commit = arg.substring('--commit='.length);
+      } else if (arg.startsWith('--')) {
+        return null;
+      } else {
+        positional.add(arg);
+      }
+    }
+    if (positional.length != 1) return null;
+
+    return _Options(
+      tag: positional.single,
+      mainRef: mainRef,
+      commit: commit,
+      skipAncestry: skipAncestry,
+    );
+  }
+}

--- a/test/scripts/release_workflow_security_test.dart
+++ b/test/scripts/release_workflow_security_test.dart
@@ -1,64 +1,258 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
 
 void main() {
-  test('publishing executes only immutable reviewed dependencies', () {
-    final workflowSources = _publishingWorkflowSources();
-    final externalUses = RegExp(
-      r'^\s*-?\s*uses:\s*([^\s]+)@([^\s#]+)',
-      multiLine: true,
-    );
+  group('every workflow and action', () {
+    test('executes only immutable reviewed dependencies', () {
+      for (final entry in _automationSources().entries) {
+        for (final match in _externalUses.allMatches(entry.value)) {
+          final action = match.group(1)!;
+          final reference = match.group(2)!;
+          expect(
+            reference,
+            matches(RegExp(r'^[0-9a-f]{40}$')),
+            reason: '$action in ${entry.key} must use a full commit SHA',
+          );
+        }
+      }
+    });
 
-    for (final entry in workflowSources.entries) {
-      for (final match in externalUses.allMatches(entry.value)) {
-        final action = match.group(1)!;
-        final reference = match.group(2)!;
+    test('runs no reusable workflow from another repository', () {
+      for (final entry in _automationSources().entries) {
+        for (final match in _anyUses.allMatches(entry.value)) {
+          final reference = match.group(1)!;
+          if (!reference.contains('.github/workflows/')) continue;
+          expect(
+            reference,
+            startsWith('./'),
+            reason:
+                '${entry.key} must call reusable workflows from this '
+                'repository, because an external branch reference is mutable',
+          );
+        }
+      }
+    });
+
+    test('executes no unverified downloaded script', () {
+      for (final entry in _automationSources().entries) {
         expect(
-          reference,
-          matches(RegExp(r'^[0-9a-f]{40}$')),
-          reason: '$action in ${entry.key} must use a full commit SHA',
+          entry.value,
+          isNot(matches(RegExp(r'curl[^\n]*\|\s*(?:ba)?sh'))),
+          reason: '${entry.key} must not execute unverified downloaded scripts',
         );
       }
-      expect(
-        entry.value,
-        isNot(matches(RegExp(r'curl[^\n]*\|\s*(?:ba)?sh'))),
-        reason: '${entry.key} must not execute unverified downloaded scripts',
-      );
-    }
+    });
+
+    test('runs on a pinned runner image', () {
+      final runner = RegExp(r'runs-on:\s*([^\s]+)', multiLine: true);
+      for (final entry in _automationSources().entries) {
+        for (final match in runner.allMatches(entry.value)) {
+          expect(
+            match.group(1),
+            isNot(endsWith('-latest')),
+            reason:
+                '${entry.key} must pin the runner image, because a rolling '
+                'image changes the toolchain without a review',
+          );
+        }
+      }
+    });
+
+    test('installs only pinned npm packages', () {
+      // `npm ci` is exact by definition, because it reads the lockfile. Every
+      // other npm invocation must name a version, either literally or through
+      // an environment variable that the workflow sets.
+      final pinned = RegExp(r'@\d+\.\d+\.\d+|@\$[A-Z_]');
+      for (final entry in _automationSources().entries) {
+        for (final line in entry.value.split('\n')) {
+          final statement = line.trim();
+          if (statement.startsWith('#')) continue;
+          if (!statement.contains('npm install') &&
+              !statement.contains('npx ')) {
+            continue;
+          }
+          expect(
+            statement,
+            matches(pinned),
+            reason:
+                '${entry.key} installs an npm package without a version: '
+                '$statement',
+          );
+        }
+      }
+    });
   });
 
-  test('the publishing Flutter SDK is versioned and checksum verified', () {
-    final workflowSources = _publishingWorkflowSources();
-    final combined = workflowSources.values.join('\n');
-    final flutterVersion = RegExp(
-      r'"flutter"\s*:\s*"([^"]+)"',
-    ).firstMatch(File('.fvmrc').readAsStringSync())!.group(1)!;
+  group('the Flutter SDK', () {
+    test('is installed only through the checksum-verified action', () {
+      final sources = _automationSources()
+        ..remove('.github/actions/setup-flutter/action.yml');
 
-    expect(flutterVersion, isNot('stable'));
-    expect(combined, contains('flutter_linux_$flutterVersion-stable.tar.xz'));
-    expect(combined, contains('sha256sum --check'));
-    expect(
-      combined,
-      matches(RegExp(r'FLUTTER_ARCHIVE_SHA256:\s*[0-9a-f]{64}')),
-    );
+      for (final entry in sources.entries) {
+        expect(
+          entry.value,
+          isNot(contains('storage.googleapis.com/flutter_infra_release')),
+          reason:
+              '${entry.key} must install Flutter through '
+              '.github/actions/setup-flutter, which verifies the checksum',
+        );
+      }
+    });
+
+    test('verifies the downloaded archive against a pinned checksum', () {
+      final action = File(
+        '.github/actions/setup-flutter/action.yml',
+      ).readAsStringSync();
+
+      expect(action, contains('sha256sum --check'));
+      expect(action, contains('.github/flutter-releases.json'));
+      expect(action, contains("--proto '=https'"));
+    });
+
+    test('pins every release that the manifest offers', () {
+      for (final entry in _flutterReleases.entries) {
+        expect(
+          entry.value['sha256'],
+          matches(RegExp(r'^[0-9a-f]{64}$')),
+          reason: 'Flutter ${entry.key} needs a full SHA-256 checksum',
+        );
+        expect(
+          entry.value['dart'],
+          matches(RegExp(r'^\d+\.\d+\.\d+$')),
+          reason: 'Flutter ${entry.key} needs the exact bundled Dart version',
+        );
+      }
+    });
+
+    test('pins the repository default to an exact manifest entry', () {
+      final pinned =
+          (jsonDecode(File('.fvmrc').readAsStringSync()) as Map)['flutter'];
+
+      expect(pinned, isNot('stable'));
+      expect(
+        _flutterReleases,
+        contains(pinned),
+        reason: '.fvmrc pins Flutter $pinned, which has no checked-in checksum',
+      );
+    });
+
+    test('pins every version that a workflow requests', () {
+      final requested = RegExp(r"flutter-version:\s*'?([0-9][^'\s]*)'?");
+      for (final entry in _automationSources().entries) {
+        for (final match in requested.allMatches(entry.value)) {
+          expect(
+            _flutterReleases,
+            contains(match.group(1)),
+            reason:
+                '${entry.key} requests Flutter ${match.group(1)}, '
+                'which has no checked-in checksum',
+          );
+        }
+      }
+    });
+  });
+
+  group('the release workflow', () {
+    test('verifies the tag and runs the preflight before publishing', () {
+      final jobs = _jobs('.github/workflows/release.yml');
+
+      expect(jobs, contains('verify-tag'));
+      expect((jobs['preflight'] as Map)['needs'], 'verify-tag');
+      expect(
+        (jobs['preflight'] as Map)['uses'],
+        './.github/workflows/preflight.yml',
+      );
+
+      for (final entry in jobs.entries) {
+        final job = entry.value as Map;
+        if (job['uses'] != './.github/workflows/publish-packages.yml') continue;
+        expect(
+          _dependencyClosure(jobs, entry.key),
+          containsAll(<String>['verify-tag', 'preflight']),
+          reason: '${entry.key} must publish only after the release checks',
+        );
+      }
+    });
+
+    test('publishes only through the protected environment', () {
+      final jobs = _jobs('.github/workflows/publish-packages.yml');
+      final publish = jobs['publish'] as Map;
+
+      expect(publish['environment'], 'Production');
+    });
+
+    test('proves the hosted dependency graph before it uploads', () {
+      final source = File(
+        '.github/workflows/publish-packages.yml',
+      ).readAsStringSync();
+
+      expect(source, contains('scripts/stage_package.dart'));
+      expect(source, contains('scripts/publish_dry_run.dart'));
+    });
   });
 }
 
-Map<String, String> _publishingWorkflowSources() {
-  const entrypoint = '.github/workflows/release.yml';
-  final sources = <String, String>{};
-  final pending = <String>[entrypoint];
-  final localWorkflow = RegExp(r'uses:\s*\./\.github/workflows/([^\s]+)');
+final _externalUses = RegExp(
+  r'^\s*-?\s*uses:\s*([^\s./][^\s]*)@([^\s#]+)',
+  multiLine: true,
+);
 
-  while (pending.isNotEmpty) {
-    final path = pending.removeLast();
-    if (sources.containsKey(path)) continue;
-    final source = File(path).readAsStringSync();
-    sources[path] = source;
-    for (final match in localWorkflow.allMatches(source)) {
-      pending.add('.github/workflows/${match.group(1)!}');
+final _anyUses = RegExp(r'^\s*-?\s*uses:\s*([^\s#]+)', multiLine: true);
+
+/// Every workflow and composite action that this repository can execute.
+Map<String, String> _automationSources() {
+  final sources = <String, String>{};
+  for (final directory in const ['.github/workflows', '.github/actions']) {
+    final entries = Directory(directory).listSync(recursive: true);
+    for (final entry in entries.whereType<File>()) {
+      if (!entry.path.endsWith('.yml') && !entry.path.endsWith('.yaml')) {
+        continue;
+      }
+      sources[entry.path] = entry.readAsStringSync();
     }
   }
+
   return sources;
+}
+
+Map<String, Map<String, Object?>> get _flutterReleases {
+  final manifest =
+      jsonDecode(File('.github/flutter-releases.json').readAsStringSync())
+          as Map;
+  final releases = manifest['releases'] as Map;
+
+  return {
+    for (final entry in releases.entries)
+      '${entry.key}': (entry.value as Map).cast<String, Object?>(),
+  };
+}
+
+Map<String, Object?> _jobs(String workflow) {
+  final document = loadYaml(File(workflow).readAsStringSync()) as Map;
+
+  return (document['jobs'] as Map).cast<String, Object?>();
+}
+
+/// Returns every job that [job] waits for, directly or indirectly.
+Set<String> _dependencyClosure(Map<String, Object?> jobs, String job) {
+  final closure = <String>{};
+  final pending = <String>[job];
+  while (pending.isNotEmpty) {
+    final current = jobs[pending.removeLast()];
+    if (current is! Map) continue;
+    final needs = current['needs'];
+    final names = switch (needs) {
+      String name => <String>[name],
+      List list => list.map((name) => '$name').toList(),
+      _ => const <String>[],
+    };
+    for (final name in names) {
+      if (closure.add(name)) pending.add(name);
+    }
+  }
+
+  return closure;
 }

--- a/test/scripts/stage_package_test.dart
+++ b/test/scripts/stage_package_test.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  late Directory output;
+
+  setUp(() {
+    output = Directory.systemTemp.createTempSync('ack-stage-');
+  });
+
+  tearDown(() {
+    if (output.existsSync()) output.deleteSync(recursive: true);
+  });
+
+  test('a staged package leaves the workspace and keeps the lint config', () {
+    final result = _stage(['ack_firebase_ai', '${output.path}/staged']);
+
+    expect(result.exitCode, 0, reason: '${result.stderr}');
+    final staged = '${result.stdout}'.trim();
+    expect(staged, endsWith('packages/ack_firebase_ai'));
+
+    final pubspec = loadYaml(File('$staged/pubspec.yaml').readAsStringSync());
+    expect((pubspec as Map).containsKey('resolution'), isFalse);
+    expect(
+      pubspec.containsKey('dependency_overrides'),
+      isFalse,
+      reason: 'a staged package must resolve its Ack dependencies from pub.dev',
+    );
+    expect((pubspec['dependencies'] as Map)['ack'], startsWith('^'));
+
+    expect(
+      File('${output.path}/staged/analysis_options.yaml').existsSync(),
+      isTrue,
+      reason: 'each package analysis_options.yaml includes the root file',
+    );
+    expect(
+      File('$staged/pubspec_overrides.yaml').existsSync(),
+      isFalse,
+      reason: 'melos path overrides would defeat the hosted resolution check',
+    );
+  });
+
+  test('--local-deps stages the dependency graph and overrides it', () {
+    final result = _stage([
+      'ack_generator',
+      '${output.path}/staged',
+      '--local-deps',
+    ]);
+
+    expect(result.exitCode, 0, reason: '${result.stderr}');
+    final staged = '${result.stdout}'.trim();
+
+    final pubspec =
+        loadYaml(File('$staged/pubspec.yaml').readAsStringSync()) as Map;
+    expect(pubspec['dependency_overrides'], {
+      'ack': {'path': '../ack'},
+      'ack_annotations': {'path': '../ack_annotations'},
+    });
+
+    for (final sibling in const ['ack', 'ack_annotations']) {
+      final siblingPubspec = File(
+        '${output.path}/staged/packages/$sibling/pubspec.yaml',
+      );
+      expect(siblingPubspec.existsSync(), isTrue);
+      expect(
+        (loadYaml(siblingPubspec.readAsStringSync()) as Map).containsKey(
+          'resolution',
+        ),
+        isFalse,
+      );
+    }
+  });
+
+  test('an unknown package reports the usage', () {
+    final result = _stage(['not_an_ack_package', '${output.path}/staged']);
+
+    expect(result.exitCode, 64);
+    expect(result.stderr, contains('Unknown package'));
+  });
+}
+
+ProcessResult _stage(List<String> args) => Process.runSync(
+  Platform.resolvedExecutable,
+  ['scripts/stage_package.dart', ...args],
+);

--- a/test/scripts/staging_test.dart
+++ b/test/scripts/staging_test.dart
@@ -1,0 +1,132 @@
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+import '../../scripts/src/staging.dart';
+
+void main() {
+  group('detachFromWorkspace', () {
+    test('removes workspace resolution so pub resolves hosted versions', () {
+      const pubspec = '''
+name: ack_firebase_ai
+version: 1.2.0
+resolution: workspace
+
+dependencies:
+  ack: ^1.2.0
+''';
+
+      final detached = loadYaml(detachFromWorkspace(pubspec)) as Map;
+
+      expect(detached.containsKey('resolution'), isFalse);
+      expect((detached['dependencies'] as Map)['ack'], '^1.2.0');
+    });
+
+    test('leaves a package that already resolves on its own', () {
+      const pubspec = 'name: ack\nversion: 1.2.0\n';
+
+      expect(detachFromWorkspace(pubspec), pubspec);
+    });
+  });
+
+  group('overrideWithStagedPackages', () {
+    test('points a dependency at the staged sibling', () {
+      const pubspec = 'name: ack_generator\ndependencies:\n  ack: ^1.2.0\n';
+
+      final overridden =
+          loadYaml(overrideWithStagedPackages(pubspec, {'ack': '../ack'}))
+              as Map;
+
+      expect((overridden['dependency_overrides'] as Map)['ack'], {
+        'path': '../ack',
+      });
+    });
+
+    test('keeps the pubspec unchanged when there is nothing to override', () {
+      const pubspec = 'name: ack\n';
+
+      expect(overrideWithStagedPackages(pubspec, const {}), pubspec);
+    });
+  });
+
+  group('toPureDartWorkspace', () {
+    test('drops the Flutter members and the Flutter SDK constraint', () {
+      const pubspec = '''
+name: ack_workspace
+
+environment:
+  sdk: '>=3.9.0 <4.0.0'
+  flutter: '>=3.35.0'
+
+workspace:
+  - packages/ack
+  - packages/ack_firebase_ai
+  - example
+''';
+
+      final pure =
+          loadYaml(
+                toPureDartWorkspace(
+                  pubspec,
+                  flutterMembers: const {'packages/ack_firebase_ai'},
+                ),
+              )
+              as Map;
+
+      expect(pure['workspace'], ['packages/ack', 'example']);
+      expect((pure['environment'] as Map).containsKey('flutter'), isFalse);
+      expect((pure['environment'] as Map)['sdk'], '>=3.9.0 <4.0.0');
+    });
+  });
+
+  group('requiresFlutter', () {
+    test('reports a Flutter SDK constraint', () {
+      expect(requiresFlutter("environment:\n  flutter: '>=3.35.0'\n"), isTrue);
+    });
+
+    test('reports a Flutter SDK dependency', () {
+      expect(
+        requiresFlutter('dev_dependencies:\n  flutter_test:\n    sdk: flutter'),
+        isTrue,
+      );
+    });
+
+    test('reports a pure-Dart package', () {
+      expect(
+        requiresFlutter("environment:\n  sdk: '>=3.9.0 <4.0.0'\n"),
+        isFalse,
+      );
+    });
+  });
+
+  test('workspaceMembers lists the declared members', () {
+    expect(workspaceMembers('workspace:\n  - packages/ack\n  - example\n'), [
+      'packages/ack',
+      'example',
+    ]);
+  });
+
+  test('directDependenciesAmong finds the Ack dependencies', () {
+    const pubspec = '''
+name: ack_generator
+dependencies:
+  ack: ^1.2.0
+  analyzer: ^10.0.0
+dev_dependencies:
+  ack_annotations: ^1.2.0
+''';
+
+    expect(
+      directDependenciesAmong(pubspec, const [
+        'ack',
+        'ack_annotations',
+        'ack_firebase_ai',
+      ]),
+      ['ack', 'ack_annotations'],
+    );
+  });
+
+  test('readPubspecVersion reads the declared version', () {
+    expect(readPubspecVersion('name: ack\nversion: 1.2.0\n'), '1.2.0');
+    expect(readPubspecVersion('name: ack_workspace\n'), isNull);
+  });
+}

--- a/test/scripts/verify_release_tag_test.dart
+++ b/test/scripts/verify_release_tag_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('the repository version is releasable under its own tag', () async {
+    final tag = 'v${_declaredAckVersion()}';
+
+    final result = await _verify([tag, '--skip-ancestry']);
+
+    expect(result.exitCode, 0, reason: '${result.stderr}');
+    expect(result.stdout, contains('$tag is releasable.'));
+  });
+
+  test('a tag that no package declares is rejected', () async {
+    final result = await _verify(['v9.9.9', '--skip-ancestry']);
+
+    expect(result.exitCode, 1);
+    expect(result.stderr, contains('packages/ack/pubspec.yaml declares'));
+    expect(result.stderr, contains('has no "## 9.9.9" heading'));
+  });
+
+  test('a tag without the release prefix is rejected', () async {
+    final result = await _verify(['1.2.0', '--skip-ancestry']);
+
+    expect(result.exitCode, 1);
+    expect(result.stderr, contains('is not a'));
+  });
+
+  test('a commit outside the release branch is rejected', () async {
+    final result = await _verify([
+      'v${_declaredAckVersion()}',
+      '--commit=${'0' * 40}',
+      '--main-ref=HEAD',
+    ]);
+
+    expect(result.exitCode, 1);
+    expect(result.stderr, contains('is not reachable from HEAD'));
+  });
+
+  test('a missing release branch is rejected', () async {
+    final result = await _verify([
+      'v${_declaredAckVersion()}',
+      '--commit=HEAD',
+      '--main-ref=refs/heads/ack-release-branch-that-does-not-exist',
+    ]);
+
+    expect(result.exitCode, 1);
+    expect(result.stderr, contains('is not available'));
+  });
+
+  test('an unknown option reports the usage', () async {
+    final result = await _verify(['v${_declaredAckVersion()}', '--unknown']);
+
+    expect(result.exitCode, 64);
+    expect(result.stderr, contains('Usage:'));
+  });
+}
+
+Future<ProcessResult> _verify(List<String> args) => Process.run(
+  Platform.resolvedExecutable,
+  ['scripts/verify_release_tag.dart', ...args],
+);
+
+/// Reads the version that the core package currently declares.
+String _declaredAckVersion() => File('packages/ack/pubspec.yaml')
+    .readAsLinesSync()
+    .firstWhere((line) => line.startsWith('version:'))
+    .split(':')
+    .last
+    .trim();


### PR DESCRIPTION
Targets `feat/ackmodel-class-first` (PR #133), not `main`. Four things this PR
needs exist only on that branch: the pinned `.fvmrc`, `publish-packages.yml`,
`test/scripts/release_workflow_security_test.dart`, and the Dart 3.9 /
Flutter 3.35 SDK floors that the minimum-SDK lanes encode. Merge this first,
then #133.

## Why

The blocking release review found three holes. Ack must not publish until all
three close.

1. **CI executed unreviewed code.** `ci.yml` called
   `conceptadev/dart-actions/.github/workflows/ci.yml@main`. That reference is
   mutable, and its FVM step piped an unverified installer into a shell.
2. **No release gate.** A `v*` tag started the publish directly. Nothing proved
   the tag pointed at reviewed code, that the packages agreed on the version,
   or that a pub.dev consumer could resolve the result.
3. **An ungated publish path.** `melos run publish` uploaded to pub.dev from any
   working tree, with no tag, no checks, and no environment review.

## What changed

**`ci: run checks locally with pinned dependencies`**
The checks now live here. `.github/actions/setup-flutter` downloads the SDK over
HTTPS only and verifies the archive against a checksum in
`.github/flutter-releases.json`. Both pinned entries match Google's official
`releases_linux.json`. `ci.yml` and `docs.yml` pin the runner image, every
external action to a commit SHA, and the docs.page CLI version.

**`ci: add the required release preflight`**
`preflight.yml` collects every pre-publish check: minimum Dart and Flutter SDK
lanes, JSON Schema Draft-7 batch validation, API comparison against the
published baseline, deterministic regeneration, and a publish dry run. The
release workflow calls the same file from the tag, so the tag gets the exact
checks the pull request got.

The complete workspace cannot resolve on the SDK floor, because `flutter_test`
pins an older `test_api` than `ack_generator`'s analyzer floor allows.
`stage_min_sdk_workspace.dart` stages the pure-Dart members into their own
workspace; `stage_package.dart` stages `ack_firebase_ai` alone for Flutter.

**`ci: verify the release tag before publishing`**
`verify_release_tag.dart` requires the tag to match every package version, to
have a matching CHANGELOG heading, and to be reachable from `main`.
`release.yml` runs verify-tag, then the full preflight, and only then publishes.
`publish-packages.yml` stages each package outside the workspace before upload,
so the run proves the hosted dependency graph rather than the workspace one, and
publishes only through the `Production` environment.

The security test now covers every workflow and composite action. It requires
commit-SHA action pins, pinned runner images and npm versions, no external
reusable workflow, no piped installer, a checksum-verified Flutter download, and
the verify-tag-then-preflight ordering ahead of every publish job.

**`chore: remove the ungated publish path`**
The `publish` and `release` melos scripts are gone, and the pubspec records why.
The inert `melos.bootstrap` block goes with them; Melos 7 resolves the workspace
from `pubspec.yaml`, so it injected nothing.

## Validation

Every gate ran locally on this branch, at the pinned Flutter 3.41.2 (Dart 3.11.0)
unless noted.

| Gate | Result |
|---|---|
| `dart run melos run ci --no-select` | pass — 6/6 packages SUCCESS |
| `dart scripts/api_check.dart 1.1.0` | pass — 0 breaking changes in all 5 |
| `melos run validate-jsonschema:batch` | pass — 78/78 |
| Minimum Dart, staged workspace on Dart 3.9.0 | pass — 5/5 analyze clean and test |
| Minimum Flutter, staged adapter on Flutter 3.35.0 | pass — analyze clean, 98 tests |
| Deterministic generation | pass — clean rebuild reproduces the tree |
| `dart scripts/publish_dry_run.dart` | pass — 5/5 with 0 warnings |
| `dart scripts/verify_release_tag.dart v1.2.0 --skip-ancestry` | pass |
| `actionlint` | pass |

## Follow-up, not in this PR

These are repository settings that only a maintainer can apply. Ack must not
tag `v1.2.0` before they are in place.

- Apply the `main` ruleset: require a pull request with an independent approval,
  and require `Run tests for all packages`, `Minimum Dart SDK`,
  `Minimum Flutter SDK`, `JSON Schema Draft-7 batch validation`,
  `API compatibility`, `Deterministic generation`, and `Publish dry run`. Do
  **not** require `validate`; the Documentation workflow runs only on doc paths
  and would block every other pull request.
- Protect the `Production` environment with a reviewer and a `v*` tag policy.
- Confirm pub.dev automated publishing for all five packages: repository
  `conceptadev/ack`, tag pattern `v{{version}}`, environment `Production`.
