### PR TITLE
feat: add ACK adapter for mcp_dart tool inputs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,7 @@
 - `packages/ack_generator`: build_runner generator + unit/integration tests.
 - `packages/ack_firebase_ai`: Firebase AI schema adapter.
 - `packages/ack_json_schema_builder`: JSON Schema adapter.
+- `packages/ack_mcp_dart`: MCP tool input schemas and typed argument validation.
 - `example`: sample usage.
 
 ## Environment and setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,4 +90,5 @@ jobs:
       packages_folder_path: "packages"
       packages: |
         ack_json_schema_builder
+        ack_mcp_dart
         ack_firebase_ai

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## 1.2.0
 
+* Add `ack_mcp_dart` for MCP tool input schemas, typed argument parsing, and
+  schema/model registration helpers with validation error results.
+
 * **Deprecated:** `@AckType()` remains available with its Ack 1.1
   extension-type behavior frozen through 1.x, but it will be removed in
   Ack 2.0.0. Use `@AckInfer()` for schema-first models or `@AckModel()` for

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -30,7 +30,7 @@ Before creating a release:
    ```
 
 4. Check that the documentation is up to date across the repo and docs site
-5. Decide on the new version number following [Semantic Versioning](https://semver.org/) and apply it consistently to every publishable package (`ack`, `ack_annotations`, `ack_generator`, `ack_firebase_ai`, `ack_json_schema_builder`)
+5. Decide on the new version number following [Semantic Versioning](https://semver.org/) and apply it consistently to every publishable package (`ack`, `ack_annotations`, `ack_generator`, `ack_firebase_ai`, `ack_json_schema_builder`, `ack_mcp_dart`)
 6. Ensure package CHANGELOG entries are finalized before tagging. If you want a link-only entry for a version, you can run `dart scripts/update_release_changelog.dart <version> [tag]` after `dart run melos version`.
 
 ### 2. Create a GitHub Release
@@ -85,7 +85,7 @@ When the `v*` tag is pushed, the GitHub Actions workflow will automatically:
    packages.
 4. After both hosted versions are available, test and publish `ack_generator`.
 5. After the generator stage completes, test and publish
-   `ack_json_schema_builder` and `ack_firebase_ai`.
+   `ack_json_schema_builder`, `ack_mcp_dart`, and `ack_firebase_ai`.
 6. Run `dart scripts/publish_dry_run.dart` immediately before each package
    upload and require zero warnings.
 
@@ -159,7 +159,7 @@ dart run melos run validate-jsonschema:batch
 dart scripts/api_check.dart <previous-version>
 
 # Only then, one package at a time, in release order:
-#   ack, ack_annotations -> ack_generator -> ack_json_schema_builder, ack_firebase_ai
+#   ack, ack_annotations -> ack_generator -> ack_json_schema_builder, ack_mcp_dart, ack_firebase_ai
 (cd packages/<package> && dart pub publish)
 ```
 
@@ -197,3 +197,8 @@ The Ack project follows [Semantic Versioning](https://semver.org/):
 - **Patch version (0.0.x)**: Backwards-compatible bug fixes
 
 For pre-releases, use formats like `0.2.0-beta.1` or `0.2.0-rc.1`.
+
+New packages have no API at an older release baseline. Record their first release
+in `ackPackageFirstReleases` in `scripts/src/workspace_packages.dart`; API checks
+skip only baselines before that version and compare normally from that version
+onward. `ack_mcp_dart` starts at 1.2.0.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This repository is a monorepo containing:
 - **[ack_generator](./packages/ack_generator)**: Generates models from schemas and schemas from hand-written models
 - **[ack_firebase_ai](./packages/ack_firebase_ai)**: Firebase AI (Gemini) schema converter for structured-output generation
 - **[ack_json_schema_builder](./packages/ack_json_schema_builder)**: Converter to `json_schema_builder` schemas
+- **[ack_mcp_dart](./packages/ack_mcp_dart)**: MCP tool schemas and typed argument validation for `mcp_dart`
 - **[example](./example)**: Example projects demonstrating usage of all packages
 
 ## Community and support

--- a/docs/guides/creating-schema-converter-packages.mdx
+++ b/docs/guides/creating-schema-converter-packages.mdx
@@ -50,6 +50,7 @@ ack_<target_system>
 
 **Examples**:
 - `ack_firebase_ai` - Firebase AI (Gemini) schemas
+- `ack_mcp_dart` - MCP tool input schemas and runtime argument validation
 - `ack_openapi` - OpenAPI 3.0/3.1 schemas
 - `ack_graphql` - GraphQL SDL schemas
 - `ack_protobuf` - Protocol Buffer schemas
@@ -1480,6 +1481,9 @@ class GraphQlSchemaConverter {
 
 ### Reference Implementations
 - **ack_firebase_ai**: Firebase AI/Gemini schemas
+- **ack_mcp_dart**: MCP tool input schemas with ACK parsing before tool callbacks.
+  Runtime adapters can use the same contract for schema export and defaults,
+  codecs, refinements, and typed model parsing; transport stays in the host SDK.
 - **ack core**: JSON Schema implementation (`toJsonSchema()`)
 
 ### Target System Documentation

--- a/llms.txt
+++ b/llms.txt
@@ -14,6 +14,7 @@ There is no `@AckSchema()` annotation; `AckSchema` is the runtime schema type.
 3. `ack_generator`: generates models from schemas and schemas from models
 4. `ack_firebase_ai`: converts Ack schemas to Firebase AI structured-output schemas
 5. `ack_json_schema_builder`: converts Ack schemas to `json_schema_builder` schemas
+6. `ack_mcp_dart`: advertises MCP tool input schemas and validates typed arguments with `mcp_dart`
 
 ## Core runtime usage
 

--- a/packages/ack_mcp_dart/.pubignore
+++ b/packages/ack_mcp_dart/.pubignore
@@ -1,0 +1,19 @@
+# Development and IDE files
+.claude/
+.idea/
+.vscode/
+
+# Build artifacts
+build/
+.dart_tool/
+
+# Coverage files
+coverage/
+
+# Local example files
+example/local/
+
+# The shared lint config. Its `include: ../../analysis_options.yaml`
+# cannot resolve outside the workspace, so shipping it breaks
+# `dart format` and `dart analyze` in the published archive.
+analysis_options.yaml

--- a/packages/ack_mcp_dart/CHANGELOG.md
+++ b/packages/ack_mcp_dart/CHANGELOG.md
@@ -1,0 +1,11 @@
+## 1.2.0
+
+### Added
+
+* Initial release: convert ACK object schemas into `mcp_dart` tool input schemas.
+* Parse tool arguments with defaults, codecs, refinements, and typed models.
+* Register schema and model tools with validation error results and optional
+  custom error handling.
+* Cover MCP 2026-07-28 discovery and 2025-11-25 / 2025-06-18 initialization.
+
+* Redact exception-backed validation messages in default tool error responses.

--- a/packages/ack_mcp_dart/LICENSE
+++ b/packages/ack_mcp_dart/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, The ACK Authors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/ack_mcp_dart/README.md
+++ b/packages/ack_mcp_dart/README.md
@@ -1,0 +1,171 @@
+# ack_mcp_dart
+
+Define an MCP tool's input contract once with ACK. Use it to advertise a
+`mcp_dart` tool schema and parse incoming arguments into validated Dart values.
+
+```text
+AckSchema → AckSchemaModel → JSON Schema → ToolInputSchema
+    │
+    └─ safeParse(arguments) → defaults, codecs, refinements → tool callback
+```
+
+Transport, negotiation, cancellation, and lifecycle remain in `mcp_dart`.
+
+## Install
+
+```yaml
+dependencies:
+  ack: ^1.2.0
+  ack_mcp_dart: ^1.2.0
+  mcp_dart: ^2.4.2
+```
+
+## Register a tool
+
+```dart
+import 'package:ack/ack.dart';
+import 'package:ack_mcp_dart/ack_mcp_dart.dart';
+import 'package:mcp_dart/mcp_dart.dart';
+
+final searchInput = Ack.object({
+  'query': Ack.string().minLength(1).refine(
+    (query) => query.trim().isNotEmpty,
+    message: 'Query must contain non-whitespace characters.',
+  ),
+  'limit': Ack.integer().min(1).max(100).optional().withDefault(5),
+});
+
+final server = McpServer(
+  const Implementation(name: 'search-server', version: '1.0.0'),
+);
+
+void registerTools() {
+  server.registerAckTool(
+    'search',
+    input: searchInput,
+    description: 'Search documents',
+    callback: (args, extra) {
+      final query = args['query'] as String;
+      final limit = args['limit'] as int; // 5 when omitted; 2.0 parses to int 2.
+      return CallToolResult(
+        content: [TextContent(text: 'Searching for $query (limit $limit)')],
+      );
+    },
+  );
+}
+```
+
+Both registration helpers return `RegisteredTool` and forward `title`,
+`description`, `annotations`, and `meta`. Callbacks may be synchronous or
+asynchronous and receive the original `RequestHandlerExtra`.
+
+Use `server.registerAckModelTool('search', model: SearchSchema.model,
+callback: (args, extra) { ... })` with an `AckModelAdapter<JsonMap, Object, M>`
+(such as a generated model adapter) to receive a typed `M` instead of a map.
+The model is constructed after ACK parses defaults and codecs.
+
+## Bare conversion and parsing
+
+Apps that own registration can use the helpers independently:
+
+```dart
+server.registerTool(
+  'search',
+  inputSchema: searchInput.toMcpToolInputSchema(),
+  callback: (args, extra) {
+    final parsed = parseMcpToolArguments(searchInput, args, debugName: 'search');
+    if (parsed case Fail(:final error)) {
+      return ackValidationErrorToCallToolResult(error, toolName: 'search');
+    }
+    return CallToolResult(
+      content: [TextContent(text: '${parsed.getOrThrow()}')],
+    );
+  },
+);
+```
+
+`describeAckValidationError(error)` returns leaf JSON Pointer paths and messages.
+The default tool error looks like:
+
+```text
+Invalid arguments for tool 'search':
+#/query: Query must contain non-whitespace characters.
+```
+
+The helpers do not append input values, error causes, or stack traces.
+Cause-backed messages (for example a codec throwing `FormatException`) become
+`Argument validation failed.` because exception text can contain input data.
+Other messages from ACK and your refinements are preserved verbatim and may
+contain values; use safe custom messages or `onInvalidArguments` when inputs
+are sensitive. Pass `onInvalidArguments`
+to either registration helper to customize ACK failures. It receives the full
+`SchemaError`; its returned `CallToolResult` is used unchanged.
+
+## Advertised schema vs runtime validation
+
+`mcp_dart` validates the advertised schema **before** invoking the ACK wrapper.
+ACK then applies defaults, codecs, and refinements. An ACK failure returns
+`isError: true`, skips the application callback, and leaves the session usable.
+It does not throw `McpError`. A parsed null is also rejected by the wrapper.
+
+| Behavior | Advertised schema | Runtime |
+| --- | --- | --- |
+| Optional default | `default` annotation; field may be omitted | ACK fills the value during parse |
+| Refinement | Predicate is not exported | ACK runs the predicate |
+| Codec / transform | Boundary shape and `x-transformed` metadata | ACK produces typed values, e.g. `DateTime` |
+| Integer | JSON Schema integer semantics | `2.0` becomes `int 2`; `2.5` fails |
+| Structural failure | Rejected by `mcp_dart` | ACK and custom invalid handler are not reached |
+
+Structural failures produce an error tool result on MCP 2025-11-25 and
+2026-07-28. MCP 2025-06-18 reports JSON-RPC `invalidParams` instead. This is
+`mcp_dart` behavior; ACK-only failures produce tool results in all tested modes.
+
+### JSON Schema dialect
+
+ACK renders Draft-7 keywords without a `$schema` declaration. `mcp_dart` uses
+2020-12 when that declaration is absent. The adapter does not stamp `$schema`
+or strip extensions: the tested ACK keyword subset works in both dialects.
+Recursive `definitions` and local `$ref` are retained, and annotated references
+are wrapped by ACK in `allOf`. Schema maps round-trip exactly; JSON object key
+order may change when `mcp_dart` serializes them.
+
+Tests pin the supported keyword set: `type`, `properties`, `required`,
+`additionalProperties`, `minimum`, `maximum`, `exclusiveMinimum`,
+`exclusiveMaximum`, `multipleOf`, `minLength`, `maxLength`, `pattern`, `format`,
+`enum`, `const`, `items`, `minItems`, `maxItems`, `uniqueItems`, `anyOf`, `oneOf`,
+`allOf`, `$ref`, `definitions`, `title`, `description`, `default`, and `x-*`.
+New emitted keywords require revisiting this dialect assumption.
+
+## Supported versions
+
+| Component | Supported / exercised |
+| --- | --- |
+| Dart | `>=3.9.0 <4.0.0` |
+| ACK | `^1.2.0` |
+| mcp_dart | `^2.4.2` (tests resolved against 2.4.2) |
+| MCP stable discovery | `2026-07-28` |
+| MCP initialization | `2025-11-25`, `2025-06-18` |
+
+## Limitations
+
+| Input / feature | Support |
+| --- | --- |
+| Plain object root (`type: object`) | Supported, including empty objects |
+| Nullable or discriminated root | Rejected at registration; renders as composition (`anyOf` in ACK 1.2) |
+| Primitive, list, or other composition root | Rejected at registration |
+| Nullable, union, discriminated, recursive, or codec **fields** | Supported inside an object |
+| Output schemas | Out of scope |
+| Transport and session controls | Use `mcp_dart` directly |
+
+## Runnable example
+
+From the repository root:
+
+```sh
+dart run packages/ack_mcp_dart/example/example.dart
+```
+
+The stdio server provides `search` and an empty-object `validate` tool. Calling
+`search` with `{"query":"dart"}` returns a limit of `5`. Calling it with
+`{"query":" "}` returns an ACK refinement error; a limit of `0` is rejected by
+MCP's structural validator. `validate` accepts `{}` or omitted arguments.

--- a/packages/ack_mcp_dart/analysis_options.yaml
+++ b/packages/ack_mcp_dart/analysis_options.yaml
@@ -1,0 +1,10 @@
+# Inherits the shared workspace config (lints + DCM presets/rules).
+# See /analysis_options.yaml at the workspace root.
+include: ../../analysis_options.yaml
+
+analyzer:
+  language:
+    # This package enforces stricter typing than the workspace default.
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true

--- a/packages/ack_mcp_dart/example/example.dart
+++ b/packages/ack_mcp_dart/example/example.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+
+import 'package:ack/ack.dart';
+import 'package:ack_mcp_dart/ack_mcp_dart.dart';
+import 'package:mcp_dart/mcp_dart.dart';
+
+/// A Station-shaped contract: query plus a bounded, defaulted result limit.
+final searchInput = Ack.object({
+  'query': Ack.string()
+      .minLength(1)
+      .describe('Search query')
+      .refine(
+        (query) => query.trim().isNotEmpty,
+        message: 'Query must contain non-whitespace characters.',
+      ),
+  'limit': Ack.integer().min(1).max(100).optional().withDefault(5),
+});
+
+Future<void> main() async {
+  final server = McpServer(
+    const Implementation(name: 'ack-search-example', version: '1.2.0'),
+  );
+  server.registerAckTool(
+    'search',
+    input: searchInput,
+    description: 'Search documents with a default limit of five.',
+    annotations: const ToolAnnotations(readOnlyHint: true),
+    callback: (args, extra) =>
+        CallToolResult(content: [TextContent(text: jsonEncode(args))]),
+  );
+  server.registerAckTool(
+    'validate',
+    input: Ack.object({}),
+    description: 'Check that the server is available.',
+    callback: (args, extra) =>
+        CallToolResult(content: [TextContent(text: 'valid')]),
+  );
+
+  // tools/call search with {"query":"dart"} returns {"query":"dart","limit":5}.
+  // {"query":" "} passes the advertised minLength but returns an ACK tool error.
+  // {"query":"dart","limit":0} fails MCP validation before the callback.
+  // Protocol messages own stdout; SDK diagnostics go to stderr.
+  await server.connect(StdioServerTransport());
+}

--- a/packages/ack_mcp_dart/lib/ack_mcp_dart.dart
+++ b/packages/ack_mcp_dart/lib/ack_mcp_dart.dart
@@ -1,0 +1,170 @@
+/// MCP tool schemas and argument validation powered by ACK.
+library;
+
+import 'dart:async';
+
+import 'package:ack/ack.dart';
+import 'package:mcp_dart/mcp_dart.dart';
+
+/// Exports ACK object contracts as MCP tool input schemas.
+extension AckMcpToolInputSchema on AckSchema<Object, Object> {
+  /// Renders with [toJsonSchema] and preserves its keywords in a [JsonObject].
+  ///
+  /// Throws [ArgumentError] unless the rendered root has `type: object`.
+  /// Composition roots (`anyOf` or `oneOf`), including nullable and
+  /// discriminated roots, cannot be advertised. Primitive and list roots
+  /// are also rejected.
+  ToolInputSchema toMcpToolInputSchema() {
+    final json = toJsonSchema();
+    if (json['type'] != 'object') {
+      final shape = json.containsKey('anyOf')
+          ? 'anyOf (nullable or union root)'
+          : json.containsKey('oneOf')
+          ? 'oneOf (discriminated root)'
+          : json['type'] ?? json.keys.join(', ');
+      throw ArgumentError(
+        'MCP tool input must render as type: object; root renders as $shape.',
+      );
+    }
+    return JsonObject.fromJson(json);
+  }
+}
+
+/// Parses MCP wire arguments, applying ACK defaults, codecs and refinements.
+SchemaResult<R> parseMcpToolArguments<R extends Object>(
+  AckSchema<JsonMap, R> schema,
+  Map<String, dynamic> args, {
+  String? debugName,
+}) => schema.safeParse(args, debugName: debugName);
+
+/// Describes validation leaves as JSON Pointer `path: message` lines.
+///
+/// Nested errors are unwrapped recursively. Empty nested errors retain their
+/// own message. Cause-backed messages are replaced with a generic message
+/// because ACK may include exception details in them. Other messages are
+/// preserved verbatim and should themselves avoid including sensitive data.
+List<String> describeAckValidationError(SchemaError error) {
+  if (error is SchemaNestedError && error.errors.isNotEmpty) {
+    return error.errors.expand(describeAckValidationError).toList();
+  }
+  // ACK can embed exception text (and its input) in a cause-backed message.
+  final message = error.cause == null
+      ? error.message
+      : 'Argument validation failed.';
+  return ['${error.path}: $message'];
+}
+
+/// Returns a tool error containing only leaf validation paths and messages.
+CallToolResult ackValidationErrorToCallToolResult(
+  SchemaError error, {
+  required String toolName,
+}) => CallToolResult(
+  isError: true,
+  content: [
+    TextContent(
+      text:
+          "Invalid arguments for tool '$toolName':\n"
+          '${describeAckValidationError(error).join('\n')}',
+    ),
+  ],
+);
+
+/// A tool callback receiving validated ACK runtime arguments and MCP context.
+typedef AckToolFunction<R> =
+    FutureOr<CallToolResult> Function(R args, RequestHandlerExtra extra);
+
+/// Registers MCP tools whose input contracts and parsing are owned by ACK.
+extension AckMcpServer on McpServer {
+  /// Advertises [input] and parses arguments before invoking [callback].
+  ///
+  /// Invalid ACK arguments return a tool error, or [onInvalidArguments]' result,
+  /// without invoking [callback]. MCP's own schema validation runs first and
+  /// its failures do not reach [onInvalidArguments]. A non-object rendered root
+  /// throws [ArgumentError] synchronously at registration.
+  RegisteredTool registerAckTool<R extends Object>(
+    String name, {
+    required AckSchema<JsonMap, R> input,
+    required AckToolFunction<R> callback,
+    String? title,
+    String? description,
+    ToolAnnotations? annotations,
+    Map<String, dynamic>? meta,
+    CallToolResult Function(SchemaError error)? onInvalidArguments,
+  }) => _registerAckTool(
+    this,
+    name,
+    input: input,
+    parse: (args) => parseMcpToolArguments(input, args, debugName: name),
+    callback: callback,
+    title: title,
+    description: description,
+    annotations: annotations,
+    meta: meta,
+    onInvalidArguments: onInvalidArguments,
+  );
+
+  /// Advertises [model]'s schema and passes a typed model to [callback].
+  ///
+  /// Defaults and codecs run before the model is constructed. Registration and
+  /// invalid-argument handling follow [registerAckTool].
+  RegisteredTool registerAckModelTool<M extends Object>(
+    String name, {
+    required AckModelAdapter<JsonMap, Object, M> model,
+    required AckToolFunction<M> callback,
+    String? title,
+    String? description,
+    ToolAnnotations? annotations,
+    Map<String, dynamic>? meta,
+    CallToolResult Function(SchemaError error)? onInvalidArguments,
+  }) => _registerAckTool(
+    this,
+    name,
+    input: model.schema,
+    parse: (args) => model.safeParse(args, debugName: name),
+    callback: callback,
+    title: title,
+    description: description,
+    annotations: annotations,
+    meta: meta,
+    onInvalidArguments: onInvalidArguments,
+  );
+}
+
+RegisteredTool _registerAckTool<R extends Object>(
+  McpServer server,
+  String name, {
+  required AckSchema<JsonMap, Object> input,
+  required SchemaResult<R> Function(Map<String, dynamic>) parse,
+  required AckToolFunction<R> callback,
+  String? title,
+  String? description,
+  ToolAnnotations? annotations,
+  Map<String, dynamic>? meta,
+  CallToolResult Function(SchemaError error)? onInvalidArguments,
+}) {
+  final inputSchema = input.toMcpToolInputSchema();
+  return server.registerTool(
+    name,
+    inputSchema: inputSchema,
+    title: title,
+    description: description,
+    annotations: annotations,
+    meta: meta,
+    callback: (args, extra) {
+      final result = parse(args);
+      if (result case Ok<R>(value: final value?)) {
+        return callback(value, extra);
+      }
+      final error = switch (result) {
+        Fail<R>(:final error) => error,
+        Ok<R>() => SchemaValidationError(
+          message: 'Tool arguments must parse to a non-null object.',
+          context: SchemaContext(name: name, schema: input, value: args),
+        ),
+      };
+      return onInvalidArguments != null
+          ? onInvalidArguments(error)
+          : ackValidationErrorToCallToolResult(error, toolName: name);
+    },
+  );
+}

--- a/packages/ack_mcp_dart/pubspec.yaml
+++ b/packages/ack_mcp_dart/pubspec.yaml
@@ -1,0 +1,21 @@
+name: ack_mcp_dart
+description: MCP tool schemas and typed argument validation for Ack and mcp_dart
+version: 1.2.0
+repository: https://github.com/conceptadev/ack
+issue_tracker: https://github.com/conceptadev/ack/issues
+resolution: workspace
+topics:
+  - json-schema
+  - schema
+  - validation
+
+environment:
+  sdk: '>=3.9.0 <4.0.0'
+
+dependencies:
+  ack: ^1.2.0
+  mcp_dart: ^2.4.2
+
+dev_dependencies:
+  lints: ^5.0.0
+  test: ^1.25.15

--- a/packages/ack_mcp_dart/test/mcp_server_integration_test.dart
+++ b/packages/ack_mcp_dart/test/mcp_server_integration_test.dart
@@ -1,0 +1,441 @@
+import 'dart:async';
+
+import 'package:ack/ack.dart';
+import 'package:ack_mcp_dart/ack_mcp_dart.dart';
+import 'package:mcp_dart/mcp_dart.dart';
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+CallToolResult textResult(String text) =>
+    CallToolResult(content: [TextContent(text: text)]);
+String resultText(CallToolResult result) =>
+    (result.content.single as TextContent).text;
+
+void main() {
+  setUpAll(silenceMcpLogs);
+  tearDownAll(resetMcpLogHandler);
+  for (final version in [null, '2025-11-25', '2025-06-18']) {
+    group(version ?? 'stable discovery (2026-07-28)', () {
+      late McpServer server;
+      late McpClient client;
+      late _TransportPair transports;
+      setUp(() {
+        server = McpServer(
+          const Implementation(name: 'ack-test', version: '1.0.0'),
+        );
+        client = McpClient(
+          const Implementation(name: 'test-client', version: '1.0.0'),
+          options: McpClientOptions(protocolVersion: version),
+        );
+        transports = _TransportPair();
+      });
+      tearDown(() async {
+        await client.close();
+        await server.close();
+        await transports.close();
+      });
+      Future<void> connect() async {
+        await server.connect(transports.server);
+        await client.connect(transports.client);
+      }
+
+      test('lists schemas and metadata for schema and model tools', () async {
+        server.registerAckTool(
+          'search',
+          input: searchSchema(),
+          title: 'Search',
+          description: 'Search documents',
+          annotations: const ToolAnnotations(readOnlyHint: true),
+          meta: {'app': 'ack'},
+          callback: (args, extra) => textResult('ok'),
+        );
+        server.registerAckModelTool(
+          'model',
+          model: searchModel,
+          title: 'Model',
+          description: 'Typed search',
+          annotations: const ToolAnnotations(readOnlyHint: true),
+          meta: {'app': 'model'},
+          callback: (args, extra) => textResult(args.query),
+        );
+        await connect();
+        final tools = (await client.listTools()).tools;
+        expect(tools, hasLength(2));
+        for (final tool in tools) {
+          expect(tool.inputSchema.toJson(), searchSchema().toJsonSchema());
+          expect(tool.annotations?.readOnlyHint, isTrue);
+        }
+        final search = tools.singleWhere((tool) => tool.name == 'search');
+        final model = tools.singleWhere((tool) => tool.name == 'model');
+        expect(search.title, 'Search');
+        expect(search.description, 'Search documents');
+        expect(search.meta, {'app': 'ack'});
+        expect(model.title, 'Model');
+        expect(model.description, 'Typed search');
+        expect(model.meta, {'app': 'model'});
+      });
+
+      test(
+        'passes defaults, normalized integers and request context',
+        () async {
+          final received = <JsonMap>[];
+          server.registerAckTool(
+            'search',
+            input: searchSchema(),
+            callback: (args, extra) async {
+              received.add(args);
+              expect(extra, isA<RequestHandlerExtra>());
+              return textResult('${args['limit']}');
+            },
+          );
+          await connect();
+          expect(
+            resultText(
+              await client.callTool(
+                const CallToolRequest(
+                  name: 'search',
+                  arguments: {'query': 'dart'},
+                ),
+              ),
+            ),
+            '5',
+          );
+          expect(
+            resultText(
+              await client.callTool(
+                const CallToolRequest(
+                  name: 'search',
+                  arguments: {'query': 'dart', 'limit': 2.0},
+                ),
+              ),
+            ),
+            '2',
+          );
+          expect(received.last['limit'], isA<int>());
+          expect(received, hasLength(2));
+        },
+      );
+
+      test('model callback receives a typed model and defaults', () async {
+        SearchInput? received;
+        server.registerAckModelTool(
+          'search',
+          model: searchModel,
+          callback: (args, extra) {
+            received = args;
+            return textResult(args.query);
+          },
+        );
+        await connect();
+        expect(
+          resultText(
+            await client.callTool(
+              const CallToolRequest(
+                name: 'search',
+                arguments: {'query': 'dart'},
+              ),
+            ),
+          ),
+          'dart',
+        );
+        expect(received?.limit, 5);
+      });
+
+      test('empty-object tools accept empty and omitted arguments', () async {
+        var calls = 0;
+        server.registerAckTool(
+          'validate',
+          input: Ack.object({}),
+          callback: (args, extra) {
+            expect(args, isEmpty);
+            calls++;
+            return textResult('valid');
+          },
+        );
+        await connect();
+        await client.callTool(
+          const CallToolRequest(name: 'validate', arguments: {}),
+        );
+        await client.callTool(const CallToolRequest(name: 'validate'));
+        expect(calls, 2);
+      });
+
+      test(
+        'model conversion exceptions are redacted and session recovers',
+        () async {
+          var calls = 0;
+          server.registerAckModelTool(
+            'number',
+            model: AckModelAdapter<JsonMap, JsonMap, int>(
+              schema: () => Ack.object({'value': Ack.string()}),
+              fromRuntime: (args) => int.parse(args['value'] as String),
+              toRuntime: (value) => {'value': '$value'},
+            ),
+            callback: (args, extra) {
+              calls++;
+              return textResult('$args');
+            },
+          );
+          await connect();
+          final failure = await client.callTool(
+            const CallToolRequest(
+              name: 'number',
+              arguments: {'value': 'PRIVATE-TOKEN-123'},
+            ),
+          );
+          expect(failure.isError, isTrue);
+          expect(resultText(failure), contains('Argument validation failed.'));
+          expect(resultText(failure), isNot(contains('PRIVATE-TOKEN-123')));
+          expect(calls, 0);
+          final success = await client.callTool(
+            const CallToolRequest(name: 'number', arguments: {'value': '7'}),
+          );
+          expect(resultText(success), '7');
+          expect(calls, 1);
+        },
+      );
+
+      test(
+        'custom invalid handler receives the original exception details',
+        () async {
+          SchemaError? received;
+          server.registerAckModelTool(
+            'number',
+            model: AckModelAdapter<JsonMap, JsonMap, int>(
+              schema: () => Ack.object({'value': Ack.string()}),
+              fromRuntime: (args) => int.parse(args['value'] as String),
+              toRuntime: (value) => {'value': '$value'},
+            ),
+            onInvalidArguments: (error) {
+              received = error;
+              return textResult('Use digits only.');
+            },
+            callback: (args, extra) =>
+                fail('Invalid arguments reached callback'),
+          );
+          await connect();
+          final result = await client.callTool(
+            const CallToolRequest(
+              name: 'number',
+              arguments: {'value': 'PRIVATE-TOKEN-123'},
+            ),
+          );
+          expect(resultText(result), 'Use digits only.');
+          expect(received?.cause, isA<FormatException>());
+          expect(received?.message, contains('PRIVATE-TOKEN-123'));
+          expect(received?.stackTrace, isNotNull);
+        },
+      );
+
+      for (final useModel in [false, true]) {
+        test(
+          'refinement failure skips ${useModel ? 'model' : 'schema'} callback and session recovers',
+          () async {
+            var calls = 0;
+            final input = searchSchema().refine(
+              (args) => args['query'] != 'blocked',
+              message: 'Query is unavailable',
+            );
+            if (useModel) {
+              server.registerAckModelTool(
+                'search',
+                model: AckModelAdapter<JsonMap, JsonMap, SearchInput>(
+                  schema: () => input,
+                  fromRuntime: searchModel.fromRuntime,
+                  toRuntime: searchModel.toRuntime,
+                ),
+                callback: (args, extra) {
+                  calls++;
+                  return textResult(args.query);
+                },
+              );
+            } else {
+              server.registerAckTool(
+                'search',
+                input: input,
+                callback: (args, extra) {
+                  calls++;
+                  return textResult(args['query'] as String);
+                },
+              );
+            }
+            await connect();
+            final invalid = await client.callTool(
+              const CallToolRequest(
+                name: 'search',
+                arguments: {'query': 'blocked'},
+              ),
+            );
+            expect(invalid.isError, isTrue);
+            expect(resultText(invalid), contains('Query is unavailable'));
+            expect(calls, 0);
+            expect(
+              resultText(
+                await client.callTool(
+                  const CallToolRequest(
+                    name: 'search',
+                    arguments: {'query': 'ok'},
+                  ),
+                ),
+              ),
+              'ok',
+            );
+            expect(calls, 1);
+          },
+        );
+
+        test(
+          'custom invalid handler for ${useModel ? 'model' : 'schema'} tool',
+          () async {
+            var calls = 0;
+            SchemaError? received;
+            final input = searchSchema().refine(
+              (args) => false,
+              message: 'Unavailable',
+            );
+            CallToolResult invalid(SchemaError error) {
+              received = error;
+              return CallToolResult(
+                isError: true,
+                content: [TextContent(text: 'custom')],
+              );
+            }
+
+            if (useModel) {
+              server.registerAckModelTool(
+                'search',
+                model: AckModelAdapter<JsonMap, JsonMap, SearchInput>(
+                  schema: () => input,
+                  fromRuntime: searchModel.fromRuntime,
+                  toRuntime: searchModel.toRuntime,
+                ),
+                onInvalidArguments: invalid,
+                callback: (args, extra) {
+                  calls++;
+                  return textResult('wrong');
+                },
+              );
+            } else {
+              server.registerAckTool(
+                'search',
+                input: input,
+                onInvalidArguments: invalid,
+                callback: (args, extra) {
+                  calls++;
+                  return textResult('wrong');
+                },
+              );
+            }
+            await connect();
+            final result = await client.callTool(
+              const CallToolRequest(
+                name: 'search',
+                arguments: {'query': 'dart'},
+              ),
+            );
+            expect(resultText(result), 'custom');
+            expect(received, isA<SchemaError>());
+            expect(calls, 0);
+          },
+        );
+      }
+
+      test(
+        'MCP structural validation skips ACK and the app callback',
+        () async {
+          var calls = 0;
+          var invalidCalls = 0;
+          server.registerAckTool(
+            'search',
+            input: searchSchema(),
+            onInvalidArguments: (error) {
+              invalidCalls++;
+              return textResult('wrong');
+            },
+            callback: (args, extra) {
+              calls++;
+              return textResult('ok');
+            },
+          );
+          await connect();
+          final result = client.callTool(
+            const CallToolRequest(
+              name: 'search',
+              arguments: {'query': 'dart', 'limit': 2.5},
+            ),
+          );
+          if (version == '2025-06-18') {
+            await expectLater(
+              result,
+              throwsA(
+                isA<McpError>().having(
+                  (e) => e.code,
+                  'code',
+                  ErrorCode.invalidParams.value,
+                ),
+              ),
+            );
+          } else {
+            expect((await result).isError, isTrue);
+          }
+          expect(calls, 0);
+          expect(invalidCalls, 0);
+          await client.callTool(
+            const CallToolRequest(name: 'search', arguments: {'query': 'ok'}),
+          );
+          expect(calls, 1);
+        },
+      );
+
+      test(
+        'nullable schema and model roots fail synchronously at registration',
+        () {
+          final input = Ack.object({}).nullable();
+          expect(
+            () => server.registerAckTool(
+              'bad',
+              input: input,
+              callback: (args, extra) => textResult('wrong'),
+            ),
+            throwsArgumentError,
+          );
+          expect(
+            () => server.registerAckModelTool(
+              'badModel',
+              model: AckModelAdapter<JsonMap, JsonMap, JsonMap>(
+                schema: () => input,
+                fromRuntime: (args) => args,
+                toRuntime: (args) => args,
+              ),
+              callback: (args, extra) => textResult('wrong'),
+            ),
+            throwsArgumentError,
+          );
+        },
+      );
+    });
+  }
+}
+
+/// Linked byte streams exercising MCP serialization and protocol negotiation.
+class _TransportPair {
+  final _toServer = StreamController<List<int>>.broadcast();
+  final _toClient = StreamController<List<int>>.broadcast();
+
+  late final client = IOStreamTransport(
+    stream: _toClient.stream,
+    sink: _toServer.sink,
+  );
+  late final server = IOStreamTransport(
+    stream: _toServer.stream,
+    sink: _toClient.sink,
+  );
+
+  Future<void> close() async {
+    await client.close();
+    await server.close();
+    await _toServer.close();
+    await _toClient.close();
+  }
+}

--- a/packages/ack_mcp_dart/test/support/fixtures.dart
+++ b/packages/ack_mcp_dart/test/support/fixtures.dart
@@ -1,0 +1,169 @@
+import 'package:ack/ack.dart';
+
+ObjectSchema searchSchema() => Ack.object({
+  'query': Ack.string().minLength(1).describe('Search query'),
+  'limit': Ack.integer().min(1).max(100).optional().withDefault(5),
+});
+
+class SearchInput {
+  const SearchInput(this.query, this.limit);
+  final String query;
+  final int limit;
+}
+
+final searchModel = AckModelAdapter<JsonMap, JsonMap, SearchInput>(
+  schema: searchSchema,
+  fromRuntime: (value) =>
+      SearchInput(value['query'] as String, value['limit'] as int),
+  toRuntime: (value) => {'query': value.query, 'limit': value.limit},
+);
+
+ObjectSchema recursiveSchema() {
+  late final ObjectSchema node;
+  node = Ack.object({
+    'name': Ack.string(),
+    'children': Ack.list(Ack.lazy('node', () => node)).optional(),
+  });
+  return node;
+}
+
+final discriminatedSchema = Ack.discriminated(
+  discriminatorKey: 'kind',
+  schemas: {
+    'text': Ack.object({'kind': Ack.literal('text'), 'text': Ack.string()}),
+    'count': Ack.object({'kind': Ack.literal('count'), 'count': Ack.integer()}),
+  },
+);
+
+// Each fixture includes both valid and invalid wire values. Refinements are
+// covered separately because they deliberately strengthen runtime validation.
+List<
+  ({
+    String name,
+    ObjectSchema schema,
+    List<JsonMap> valid,
+    List<JsonMap> invalid,
+  })
+>
+schemaFixtures() => [
+  (
+    name: 'search',
+    schema: searchSchema(),
+    valid: [
+      {'query': 'dart'},
+      {'query': 'dart', 'limit': 2.0},
+    ],
+    invalid: [
+      {},
+      {'query': ''},
+      {'query': 'dart', 'limit': 2.5},
+      {'query': 'dart', 'limit': 101},
+    ],
+  ),
+  (
+    name: 'empty',
+    schema: Ack.object({}),
+    valid: [{}],
+    invalid: [
+      {'extra': true},
+    ],
+  ),
+  (
+    name: 'fields',
+    schema: Ack.object({
+      'optional': Ack.string().optional(),
+      'nullable': Ack.string().nullable(),
+      'enum': Ack.enumString(['one', 'two']),
+      'bounded': Ack.string().minLength(2).maxLength(5).matches('^[a-z]+\$'),
+      'number': Ack.number().min(0).max(10),
+      'list': Ack.list(Ack.integer()).minItems(1).maxItems(3).unique(),
+      'nested': Ack.object({'value': Ack.boolean()}),
+    }),
+    valid: [
+      {
+        'nullable': null,
+        'enum': 'one',
+        'bounded': 'abc',
+        'number': 1.5,
+        'list': [1, 2],
+        'nested': {'value': true},
+      },
+    ],
+    invalid: [
+      {
+        'nullable': null,
+        'enum': 'three',
+        'bounded': 'A',
+        'number': 11,
+        'list': [],
+        'nested': {'value': 2},
+      },
+      {},
+    ],
+  ),
+  (
+    name: 'union',
+    schema: Ack.object({
+      'value': Ack.anyOf([Ack.string(), Ack.integer()]),
+    }),
+    valid: [
+      {'value': 'a'},
+      {'value': 2},
+    ],
+    invalid: [
+      {'value': false},
+    ],
+  ),
+  (
+    name: 'discriminated field',
+    schema: Ack.object({'value': discriminatedSchema}),
+    valid: [
+      {
+        'value': {'kind': 'count', 'count': 2},
+      },
+    ],
+    invalid: [
+      {
+        'value': {'kind': 'text', 'count': 2},
+      },
+    ],
+  ),
+  (
+    name: 'recursive',
+    schema: recursiveSchema(),
+    valid: [
+      {
+        'name': 'root',
+        'children': [
+          {'name': 'leaf'},
+        ],
+      },
+    ],
+    invalid: [
+      {
+        'name': 'root',
+        'children': [
+          {'name': 2},
+        ],
+      },
+    ],
+  ),
+  (
+    name: 'codecs',
+    schema: Ack.object({
+      'at': Ack.datetime(),
+      'url': Ack.uri(),
+      'duration': Ack.duration(),
+    }),
+    valid: [
+      {
+        'at': '2026-09-10T12:00:00Z',
+        'url': 'https://example.com',
+        'duration': 1000,
+      },
+    ],
+    invalid: [
+      {'at': 3, 'url': false, 'duration': 'long'},
+    ],
+  ),
+];

--- a/packages/ack_mcp_dart/test/tool_arguments_test.dart
+++ b/packages/ack_mcp_dart/test/tool_arguments_test.dart
@@ -1,0 +1,126 @@
+import 'package:ack/ack.dart';
+import 'package:ack_mcp_dart/ack_mcp_dart.dart';
+import 'package:mcp_dart/mcp_dart.dart';
+import 'package:test/test.dart';
+
+import 'support/fixtures.dart';
+
+void main() {
+  test('applies defaults and normalizes integral doubles', () {
+    final schema = searchSchema();
+    expect(parseMcpToolArguments(schema, {'query': 'dart'}).getOrThrow(), {
+      'query': 'dart',
+      'limit': 5,
+    });
+    final parsed = parseMcpToolArguments(schema, {
+      'query': 'dart',
+      'limit': 2.0,
+    }).getOrThrow()!;
+    expect(parsed['limit'], isA<int>().having((v) => v, 'value', 2));
+    expect(
+      parseMcpToolArguments(schema, {'query': 'dart', 'limit': 2.5}).isFail,
+      isTrue,
+    );
+  });
+
+  test('decodes a datetime without changing its wire schema', () {
+    final schema = Ack.object({'at': Ack.datetime()});
+    final wire = schema.toJsonSchema();
+    final parsed = parseMcpToolArguments(schema, {
+      'at': '2026-09-10T12:00:00Z',
+    }).getOrThrow()!;
+    expect(parsed['at'], DateTime.utc(2026, 9, 10, 12));
+    expect(schema.toJsonSchema(), wire);
+  });
+
+  test('model adapter receives the validated runtime defaults', () {
+    final result = searchModel.safeParse({'query': 'dart'}).getOrThrow()!;
+    expect(result.query, 'dart');
+    expect(result.limit, 5);
+  });
+
+  test('flattens nested refinement and list failures to leaf paths', () {
+    final schema = Ack.object({
+      'items': Ack.list(
+        Ack.object({
+          'value': Ack.string().refine((v) => v == 'ok', message: 'Must be ok'),
+        }),
+      ),
+    });
+    final error = parseMcpToolArguments(schema, {
+      'items': [
+        {'value': 'secret-value'},
+      ],
+    }, debugName: 'search').getError();
+    expect(error.name, 'search');
+    final lines = describeAckValidationError(error);
+    expect(lines, hasLength(1));
+    expect(lines.single, contains('#/items/0/value: '));
+    expect(lines.single, contains('Must be ok'));
+    final result = ackValidationErrorToCallToolResult(
+      error,
+      toolName: 'search',
+    );
+    expect(result.isError, isTrue);
+    final text = (result.content.single as TextContent).text;
+    expect(text, startsWith("Invalid arguments for tool 'search':"));
+    expect(text, contains(lines.single));
+    expect(text, isNot(contains('secret-value')));
+    expect(text, isNot(contains('StackTrace')));
+  });
+
+  test('never includes cause, stack trace or context value', () {
+    final error = SchemaValidationError(
+      message: 'Invalid input',
+      context: SchemaContext(
+        name: 'input',
+        schema: Ack.object({}),
+        value: 'secret-value',
+      ),
+      cause: 'secret-cause',
+      stackTrace: StackTrace.fromString('secret-stack'),
+    );
+    expect(describeAckValidationError(error), [
+      '#: Argument validation failed.',
+    ]);
+    expect(
+      (ackValidationErrorToCallToolResult(error, toolName: 'x').content.single
+              as TextContent)
+          .text,
+      "Invalid arguments for tool 'x':\n#: Argument validation failed.",
+    );
+  });
+
+  for (final input in [
+    Ack.object({
+      'token': Ack.string().refine(
+        (value) => int.parse(value) > 0,
+        message: 'Must be positive',
+      ),
+    }),
+    Ack.object({'token': Ack.string().transform(int.parse)}),
+  ]) {
+    test('exception-backed failures do not expose exception text or input', () {
+      final error = parseMcpToolArguments(input, {
+        'token': 'PRIVATE-TOKEN-123',
+      }).getError();
+      final lines = describeAckValidationError(error);
+      expect(lines, ['#/token: Argument validation failed.']);
+      final result = ackValidationErrorToCallToolResult(
+        error,
+        toolName: 'search',
+      );
+      final text = (result.content.single as TextContent).text;
+      expect(text, isNot(contains('PRIVATE-TOKEN-123')));
+      expect(text, isNot(contains('FormatException')));
+    });
+  }
+
+  test('empty nested error falls back to its own message', () {
+    final error = SchemaNestedError(
+      errors: [],
+      context: SchemaContext(name: 'input', schema: Ack.object({}), value: {}),
+    );
+    expect(describeAckValidationError(error), ['#: ${error.message}']);
+  });
+}

--- a/packages/ack_mcp_dart/test/tool_input_schema_test.dart
+++ b/packages/ack_mcp_dart/test/tool_input_schema_test.dart
@@ -1,0 +1,133 @@
+import 'package:ack/ack.dart';
+import 'package:ack_mcp_dart/ack_mcp_dart.dart';
+import 'package:test/test.dart';
+import 'package:mcp_dart/mcp_dart.dart';
+
+import 'support/fixtures.dart';
+
+void main() {
+  test('Station-shaped search contract is preserved exactly', () {
+    final schema = searchSchema();
+    final expected = {
+      'type': 'object',
+      'properties': {
+        'query': {
+          'type': 'string',
+          'minLength': 1,
+          'description': 'Search query',
+        },
+        'limit': {
+          'type': 'integer',
+          'minimum': 1,
+          'maximum': 100,
+          'default': 5,
+        },
+      },
+      'required': ['query'],
+      'additionalProperties': false,
+    };
+    expect(schema.toMcpToolInputSchema().toJson(), expected);
+    expect(schema.toMcpToolInputSchema().toJson(), schema.toJsonSchema());
+  });
+
+  for (final fixture in schemaFixtures()) {
+    group(fixture.name, () {
+      test('round trips every keyword and stays within the dialect subset', () {
+        final json = fixture.schema.toJsonSchema();
+        expect(fixture.schema.toMcpToolInputSchema().toJson(), json);
+        checkKeywords(json);
+      });
+      test('MCP and ACK agree on acceptance', () {
+        final mcp = fixture.schema.toMcpToolInputSchema();
+        for (final args in fixture.valid) {
+          expect(() => mcp.validate(args), returnsNormally, reason: '$args');
+          expect(fixture.schema.safeParse(args).isOk, isTrue, reason: '$args');
+        }
+        for (final args in fixture.invalid) {
+          expect(
+            () => mcp.validate(args),
+            throwsA(isA<JsonSchemaValidationException>()),
+            reason: '$args',
+          );
+          expect(
+            fixture.schema.safeParse(args).isFail,
+            isTrue,
+            reason: '$args',
+          );
+        }
+      });
+    });
+  }
+
+  for (final (schema, shape) in <(AckSchema<Object, Object>, String)>[
+    (Ack.object({}).nullable(), 'anyOf'),
+    (discriminatedSchema, 'anyOf'),
+    (Ack.string(), 'string'),
+    (Ack.list(Ack.string()), 'array'),
+  ]) {
+    test('rejects $shape root with an actionable message', () {
+      expect(
+        schema.toMcpToolInputSchema,
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains(shape),
+          ),
+        ),
+      );
+    });
+  }
+}
+
+// Property/definition names and literal defaults are data, not schema keywords.
+void checkKeywords(Map<String, Object?> schema) {
+  const allowed = {
+    'type',
+    'properties',
+    'required',
+    'additionalProperties',
+    'minimum',
+    'maximum',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+    'multipleOf',
+    'minLength',
+    'maxLength',
+    'pattern',
+    'format',
+    'enum',
+    'const',
+    'items',
+    'minItems',
+    'maxItems',
+    'uniqueItems',
+    'anyOf',
+    'oneOf',
+    'allOf',
+    r'$ref',
+    'definitions',
+    'title',
+    'description',
+    'default',
+  };
+  for (final MapEntry(:key, :value) in schema.entries) {
+    expect(
+      allowed.contains(key) || key.startsWith('x-'),
+      isTrue,
+      reason: 'New keyword $key: revisit the README dialect guarantee',
+    );
+    if (key == 'properties' || key == 'definitions') {
+      for (final child in (value! as Map<String, Object?>).values) {
+        checkKeywords(child! as Map<String, Object?>);
+      }
+    } else if (key == 'anyOf' || key == 'oneOf' || key == 'allOf') {
+      for (final child in value! as List<Object?>) {
+        checkKeywords(child! as Map<String, Object?>);
+      }
+    } else if ((key == 'items' || key == 'additionalProperties') &&
+        value is Map<String, Object?>) {
+      checkKeywords(value);
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ workspace:
   - packages/ack_generator
   - packages/ack_firebase_ai
   - packages/ack_json_schema_builder
+  - packages/ack_mcp_dart
   - example
 
 dependencies:
@@ -20,6 +21,7 @@ dev_dependencies:
   melos: ^7.3.0
   # Release tooling under /scripts reads and rewrites pubspecs.
   path: ^1.9.0
+  pub_semver: ^2.2.0
   test: ^1.25.15
   very_good_analysis: ^9.0.0
   yaml: ^3.1.2
@@ -58,6 +60,7 @@ melos:
           - ack_generator
           - ack_firebase_ai
           - ack_json_schema_builder
+          - ack_mcp_dart
           - ack_example
           - ack_annotations
 

--- a/scripts/api_check.dart
+++ b/scripts/api_check.dart
@@ -3,6 +3,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:pub_semver/pub_semver.dart';
+
 import 'src/workspace_packages.dart';
 
 final ackPackages = publishableAckPackages;
@@ -50,6 +52,21 @@ Future<void> main(List<String> args) async {
 
   print('🚀 API Compatibility Check vs $version');
 
+  final requestedPackages = packageName != null ? [packageName] : ackPackages;
+  final baseline = Version.parse(cleanVersion);
+  final packagesToCheck = requestedPackages.where((package) {
+    final firstRelease = ackPackageFirstReleases[package];
+    if (firstRelease != null && baseline < Version.parse(firstRelease)) {
+      print(
+        'Skipping $package: $package first releases in $firstRelease; '
+        'no API exists at baseline $cleanVersion.',
+      );
+      return false;
+    }
+    return true;
+  }).toList();
+  if (packagesToCheck.isEmpty) return;
+
   // Activate dart_apitool
   final activated = await runCommand('dart', [
     'pub',
@@ -65,7 +82,6 @@ Future<void> main(List<String> args) async {
   }
 
   // Check packages
-  final packagesToCheck = packageName != null ? [packageName] : ackPackages;
   final reports = <String>[];
   var hasFailures = false;
 

--- a/scripts/src/workspace_packages.dart
+++ b/scripts/src/workspace_packages.dart
@@ -5,4 +5,9 @@ const publishableAckPackages = <String>[
   'ack_generator',
   'ack_firebase_ai',
   'ack_json_schema_builder',
+  'ack_mcp_dart',
 ];
+
+/// First releases for packages added after the original workspace baseline.
+/// Earlier versions have no published API to compare against.
+const ackPackageFirstReleases = <String, String>{'ack_mcp_dart': '1.2.0'};

--- a/test/scripts/api_check_test.dart
+++ b/test/scripts/api_check_test.dart
@@ -3,6 +3,39 @@ import 'dart:io';
 import 'package:test/test.dart';
 
 void main() {
+  for (final baseline in ['1.1.0', '1.2.0']) {
+    test(
+      'new adapter API baseline $baseline respects its first release',
+      () async {
+        final fakeBin = Directory.systemTemp.createTempSync(
+          'ack-api-first-release-',
+        );
+        addTearDown(() => fakeBin.deleteSync(recursive: true));
+        _writeExecutable(fakeBin, 'dart', '#!/bin/sh\nexit 23\n');
+        final result = await Process.run(
+          Platform.resolvedExecutable,
+          ['scripts/api_check.dart', 'ack_mcp_dart', baseline],
+          environment: {
+            ...Platform.environment,
+            'PATH': '${fakeBin.path}:/usr/bin:/bin',
+          },
+        );
+        if (baseline == '1.1.0') {
+          expect(result.exitCode, 0);
+          expect(
+            result.stdout,
+            contains('ack_mcp_dart first releases in 1.2.0'),
+          );
+          expect(result.stderr, isEmpty);
+        } else {
+          expect(result.exitCode, 1);
+          expect(result.stderr, contains('Unable to activate dart_apitool'));
+        }
+      },
+      skip: Platform.isWindows ? 'Uses POSIX test executables.' : false,
+    );
+  }
+
   test(
     'activation failures stop API checks with a non-zero exit code',
     () async {

--- a/test/scripts/release_changelog_test.dart
+++ b/test/scripts/release_changelog_test.dart
@@ -112,6 +112,7 @@ Duplicate stable notes.
       'packages/ack_generator/CHANGELOG.md',
       'packages/ack_firebase_ai/CHANGELOG.md',
       'packages/ack_json_schema_builder/CHANGELOG.md',
+      'packages/ack_mcp_dart/CHANGELOG.md',
     ];
     final originals = <String, String>{};
     for (final path in paths) {

--- a/test/scripts/release_documentation_test.dart
+++ b/test/scripts/release_documentation_test.dart
@@ -8,6 +8,7 @@ void main() {
     for (final package in const [
       'ack_firebase_ai',
       'ack_json_schema_builder',
+      'ack_mcp_dart',
     ]) {
       final directory = 'packages/$package';
       final pubspec = loadYaml(


### PR DESCRIPTION
## Summary

Add `ack_mcp_dart` so applications advertise ACK object contracts and parse tool arguments with defaults, codecs, refinements, typed models, and validation error results, including redaction of exception-backed diagnostics.
Include a stdio example, protocol coverage, documentation, and workspace/release wiring with API checks that skip baselines before the package's first release.

## Validation

63 adapter tests, 48 release-script tests, strict analysis, stdio smoke testing, and staged publish validation passed with zero packaging warnings.
Dart 3.9 minimum-SDK verification remains pending CI because local disk space prevented SDK installation.

Closes #139
