### PR TITLE
fix(ci): publish with --skip-validation to survive the pub.dev 403

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -164,6 +164,12 @@ jobs:
           sdk: ${{ steps.flutter.outputs.dart-version }}
           problem-matcher: false
 
+      # `Validate package publication` above already resolved and validated
+      # this package without a credential. Repeating that resolution here
+      # authenticates the public version-listing and advisory reads, which
+      # pub.dev now answers with HTTP 403 before the upload can start:
+      # https://github.com/dart-lang/pub-dev/issues/9576. Drop the flag once
+      # that is fixed. pub.dev still validates the archive server-side.
       - name: Publish package with pub.dev OIDC
         if: steps.publication.outputs.published != 'true'
         working-directory: ${{ inputs.packages_folder_path }}/${{ matrix.package }}
@@ -171,4 +177,4 @@ jobs:
           SDK: ${{ steps.sdk.outputs.executable }}
         run: |
           set -euo pipefail
-          "$SDK" pub publish --force
+          "$SDK" pub publish --force --skip-validation


### PR DESCRIPTION
## Problem

pub.dev returns `403` with a Cloud Storage `AccessDenied` body for `GET /api/packages/<pkg>` and `GET /api/packages/<pkg>/advisories` whenever the request carries an `Authorization: Bearer` header. It worked on 2026-09-05 and was failing by 2026-09-10. Filed upstream as `dart-lang/pub-dev#9576`.

`dart-lang/setup-dart` registers the OIDC token for the whole `https://pub.dev` host, so the pub client attaches it to every request. `pub publish` always resolves before uploading, and that resolution prefetches the version listing and advisories. On a fresh runner the publish step therefore fails with `Authentication error (403)` before the upload starts.

This already took down three release runs in `conceptadev/remix`; the same fix got beta.9 out.

## Change

One flag on the final publish step, plus a comment pointing at the upstream issue.

```diff
-          "$SDK" pub publish --force
+          "$SDK" pub publish --force --skip-validation
```

## Why this is safe

- `Validate package publication` (`scripts/publish_dry_run.dart`) runs **before** `Provision pub.dev OIDC credentials`, so full client-side validation and resolution still happen, uncredentialed.
- The staged-package resolution, analysis and test steps also run before the token exists and are unaffected.
- Nothing modifies the package tree between validation and publish — `Restore the reviewed package tree` guarantees it.
- `--skip-validation` only skips the *repeated* client-side pass. pub.dev still validates the archive server-side on upload.

## Verification

- `actionlint .github/workflows/publish-packages.yml` — clean.
- `dart test test/scripts/release_workflow_security_test.dart` — 15/15 pass, including `provisions pub.dev OIDC credentials before publishing`.
- Real-world proof: the identical change published `remix` and `remix_fortal` 1.0.0-beta.9 today.

## Follow-up

Revert this flag once `dart-lang/pub-dev#9576` is fixed.