### PR TITLE
feat: add Optional, Required, and NotNull field annotations

### DIFF
--- a/docs/architecture/ackinfer-model-generation.md
+++ b/docs/architecture/ackinfer-model-generation.md
@@ -81,7 +81,9 @@ consumers. `capture` stores them in `captureField` (defaults to
 `additionalProperties`, may be `args`) and is required for model round trips.
 Declared fields and discriminators win on encode.
 
-`@AckField` may override `schema` and/or `AckFieldPresence`. A no-op
+`@AckField` may override `schema`. Prefer `@Optional()` and `@Required()` for
+key presence; `@NotNull()` rejects an explicit JSON `null` without requiring the
+key. Deprecated `AckField.presence` remains accepted during migration. A no-op
 `@AckField()` is rejected. `optional` is allowed only when the constructor can
 accept a missing value, with a discriminator exception for union branches.
 
@@ -146,7 +148,8 @@ Analysis produces one graph consumed directly by the emitter. Nodes carry:
 - named model references.
 
 The internal graph presence enum is `AckSchemaFieldPresence` so it does not
-collide with the public `AckFieldPresence` annotation.
+collide with the public `@Optional()` / `@Required()` annotations or the
+deprecated `AckFieldPresence` API.
 
 All annotated declarations are registered before resolution. Resolution uses
 `unseen`, `visiting`, and `resolved` states: named `Ack.lazy` edges may point to

--- a/docs/core-concepts/typesafe-schemas.mdx
+++ b/docs/core-concepts/typesafe-schemas.mdx
@@ -234,6 +234,31 @@ Nullable defaults keep their source-level behavior. With
 null. With `this.label = null`, missing input and JSON `null` parse as null and
 the encoded object keeps the key with a null value.
 
+Use `@Optional()` or `@Required()` to override inferred key presence. These
+control whether the JSON key must exist; they do not change Dart nullability.
+Unannotated fields keep constructor inference.
+
+Use `@NotNull()` when the Dart type is nullable (`String?`) but a present JSON
+value must not be `null`. Do not add it on non-nullable fields such as
+`Map<String, V>` — those already reject JSON `null`. `@Optional()` alone on
+`String?` still accepts JSON `null`, matching legacy `presence: optional`
+behavior. `@Optional()` is redundant when the constructor already treats the
+field as optional; `@NotNull()` is the annotation that changes null acceptance:
+
+```dart
+@AckModel()
+final class Example with _$ExampleAck {
+  const Example({this.label});
+
+  @Optional()
+  @NotNull()
+  final String? label;
+}
+```
+
+`ExampleSchema.parse({})` yields `label: null`, `{"label": "hello"}` succeeds,
+and `{"label": null}` fails. Encoding omits a null Dart value.
+
 The generator infers `String`, `bool`, numeric types, `DateTime`, `Uri`,
 `Duration`, enums, nested lists, and sets. Sets use a list codec.
 
@@ -253,8 +278,7 @@ schema and generated JSON mapping cannot diverge.
 ### Custom field schemas
 
 Use `@AckField` when inference is not enough. `schema` is a const tear-off of a
-top-level function returning an `AckSchema`. `presence` overrides constructor
-inference. At least one of those arguments is required:
+top-level function returning an `AckSchema`. A no-op `@AckField()` is rejected.
 
 ```dart
 final class Color {
@@ -283,6 +307,30 @@ Automatic `List<T>` and `Set<T>` inference also requires non-nullable element
 types because `Ack.list` has no nullable-item contract. An explicit
 `@AckField(schema: ...)` codec remains the escape hatch when a field deliberately
 uses a different collection representation.
+
+`@AckField(presence: ...)` is deprecated. Migrate to field annotations:
+
+```dart
+// Optional
+@Optional()
+final String? summary;
+
+// Required
+@Required()
+final String? summary;
+
+// Inferred: omit presence annotations
+
+// Schema plus presence
+@Optional()
+@AckField(schema: parametersSchema)
+final Map<String, ParameterEntry> parameters;
+```
+
+Matching legacy and new declarations are accepted with a deprecation warning.
+Conflicting declarations and combining `@Optional()` with `@Required()` are
+errors. `@Optional()` is allowed only when the constructor can accept a missing
+value, with a discriminator exception for union branches.
 
 ### Class-first unions
 
@@ -338,11 +386,6 @@ discriminator cannot be replaced by an extra value. Models that must round-trip
 unknown keys must use `capture`, not `discard`. Hand-written constructors can
 call `deepUnmodifiableJsonMap` to detach and recursively freeze direct map
 inputs without validating them.
-
-`@AckField` can override inferred presence with `AckFieldPresence.required` or
-`optional`. A no-op `@AckField()` is rejected. `optional` is allowed only when
-the constructor can accept a missing value, with a discriminator exception for
-union branches.
 
 ### Reusing generated schemas
 

--- a/llms.txt
+++ b/llms.txt
@@ -110,8 +110,10 @@ equality. The facade exposes `schema`, `wireSchema`, `parse`, `safeParse`,
 lower-camel alias is emitted. Constructor parameters determine presence and
 defaults. Field types and constraint annotations determine the schema. Sealed
 classes use `@AckModel(discriminatorKey: ...)`; same-library concrete branches
-are included automatically. Use `@AckField` to override `schema` and/or
-`AckFieldPresence`. Unknown properties use
+are included automatically. Use `@Optional()` or `@Required()` to override
+inferred key presence, `@NotNull()` to reject an explicit JSON `null` without
+requiring the key, and `@AckField(schema: ...)` for custom field codecs.
+Deprecated `AckFieldPresence` remains available during migration. Unknown properties use
 `unknownProperties: AckUnknownPropertyPolicy.<policy>` (`reject` by default).
 Raw `Ack.object(..., additionalProperties: true)` validation preserves extras;
 the class-first policy is a later projection. `discard` is for tolerant,
@@ -152,8 +154,9 @@ cross-library discriminated branches.
 
 Class-first generation supports object models, inferred scalar and enum
 fields, nested lists, sets through list codecs, custom `@AckField` schemas,
-constructor defaults, case styles, `AckUnknownPropertyPolicy`, and
-same-library sealed discriminated unions. It rejects `dynamic`, `Object?`,
+`@Optional()`, `@Required()`, `@NotNull()`, constructor defaults, case styles,
+`AckUnknownPropertyPolicy`, and same-library sealed discriminated unions. It
+rejects `dynamic`, `Object?`,
 non-String map keys, recursive class-first graphs, class-first value roots,
 undiscriminated `anyOf` models, missing `_$ClassAck` mixins, and no-op
 `@AckField()`.

--- a/packages/ack_annotations/CHANGELOG.md
+++ b/packages/ack_annotations/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+### Added
+
+* Add `@Optional()`, `@Required()`, and `@NotNull()` field annotations for
+  class-first key presence and JSON null rejection.
+
+### Deprecated
+
+* Deprecate `AckField.presence` and `AckFieldPresence`. Use `@Optional()` or
+  `@Required()`; they will be removed in Ack 2.0.0.
+
 ## 1.3.0
 
 ### Changed

--- a/packages/ack_annotations/README.md
+++ b/packages/ack_annotations/README.md
@@ -94,5 +94,8 @@ final. Instantiable models apply the generated `_$ClassAck` mixin. The public
 Unknown properties use `unknownProperties: AckUnknownPropertyPolicy.<policy>`.
 Use `discard` only for tolerant, read-only consumers; models that round-trip
 unknown keys use `capture` and may select their map field with `captureField`.
-`@AckField` can override `schema` and/or `AckFieldPresence`. See the
+`@AckField` can override `schema`. Use `@Optional()` and `@Required()` for
+key presence, and `@NotNull()` when an omitted key is allowed but an explicit
+JSON `null` is not. Deprecated `AckFieldPresence` remains available during
+migration. See the
 [Model Code Generation guide](https://concepta.dev/documentation/ack/advanced/typesafe-schemas).

--- a/packages/ack_annotations/example/example.dart
+++ b/packages/ack_annotations/example/example.dart
@@ -44,7 +44,8 @@ final class TolerantPayload {
   final Map<String, Object?> extras;
 }
 
-/// `@AckField()` overrides what the constructor implies for one field.
+/// `@Required()` and `@Optional()` override what the constructor implies for one
+/// field. Keep `@AckField(schema: ...)` for custom field codecs.
 @AckModel()
 final class Article {
   const Article({required this.title, this.summary});
@@ -53,7 +54,7 @@ final class Article {
   final String title;
 
   /// The constructor allows a missing value, so mark the key required anyway.
-  @AckField(presence: AckFieldPresence.required)
+  @Required()
   final String? summary;
 }
 

--- a/packages/ack_annotations/lib/ack_annotations.dart
+++ b/packages/ack_annotations/lib/ack_annotations.dart
@@ -5,8 +5,10 @@
 /// Deprecated `@AckType()` remains available for Ack 1.1 compatibility.
 ///
 /// Class-first models apply the generated `_$ClassAck` mixin and may use
-/// [AckUnknownPropertyPolicy] and [AckFieldPresence] to describe wire
-/// extras and field presence.
+/// [AckUnknownPropertyPolicy], `@Optional()`, `@Required()`, `@NotNull()`,
+/// and `@AckField(schema: ...)` to describe wire extras, field presence,
+/// and custom field codecs. Deprecated [AckFieldPresence] remains available
+/// during migration.
 library;
 
 export 'package:json_annotation/json_annotation.dart' show JsonKey;

--- a/packages/ack_annotations/lib/src/ack_field.dart
+++ b/packages/ack_annotations/lib/src/ack_field.dart
@@ -1,25 +1,78 @@
 import 'package:meta/meta_meta.dart';
 
+// The deprecated presence API is defined in this file.
+// ignore_for_file: deprecated_member_use_from_same_package
+
 /// Overrides inferred input-presence for a class-first field.
 ///
 /// [inferred] keeps constructor-based presence. [required] always requires the
 /// JSON key. [optional] is valid only when the constructor can accept a missing
 /// value, with a discriminator-specific exception for union branches.
+@Deprecated(
+  'Use @Optional() or @Required(). AckFieldPresence will be removed in 2.0.0.',
+)
 enum AckFieldPresence { inferred, required, optional }
+
+/// Marks a class-first field as optional on the wire.
+///
+/// The JSON key may be omitted. This does not change whether a present JSON
+/// value may be `null`: a nullable Dart type still accepts JSON `null`, and
+/// `@NotNull()` rejects it. Valid only when the constructor can accept a
+/// missing value, with a discriminator-specific exception for union branches.
+@Target({TargetKind.field})
+final class Optional {
+  /// Creates an optional-presence annotation.
+  const Optional();
+}
+
+/// Marks a class-first field as required on the wire.
+///
+/// The JSON key must be present. This does not change Dart nullability.
+@Target({TargetKind.field})
+final class Required {
+  /// Creates a required-presence annotation.
+  const Required();
+}
+
+/// Rejects an explicit JSON `null` without requiring the key to exist.
+///
+/// Needed only when the Dart type is nullable but a present JSON value must not
+/// be `null`. Non-nullable Dart fields already reject JSON `null`; do not add
+/// this annotation there. Dart nullability is unchanged: an omitted optional key
+/// still becomes `null` on a nullable field, and encoding omits a null Dart
+/// value.
+@Target({TargetKind.field})
+final class NotNull {
+  /// Creates a JSON null-rejection annotation.
+  const NotNull();
+}
 
 /// Overrides the inferred schema and/or presence for a class-first field.
 ///
 /// [schema] must be a const tear-off of a top-level function returning an Ack
 /// schema. The generator validates the declaration and follows its expression.
 /// A no-op `@AckField()` is rejected.
+///
+/// Prefer `@Optional()` and `@Required()` for key presence. [presence] is
+/// deprecated and will be removed in 2.0.0.
 @Target({TargetKind.field})
 final class AckField {
   /// Creates a field annotation.
-  const AckField({this.schema, this.presence = AckFieldPresence.inferred});
+  const AckField({
+    this.schema,
+    @Deprecated(
+      'Use @Optional() or @Required(). AckField.presence will be removed in '
+      '2.0.0.',
+    )
+    this.presence = AckFieldPresence.inferred,
+  });
 
   /// Top-level schema-function tear-off followed by `ack_generator`.
   final Object Function()? schema;
 
   /// Presence override applied after constructor inference.
+  @Deprecated(
+    'Use @Optional() or @Required(). AckField.presence will be removed in 2.0.0.',
+  )
   final AckFieldPresence presence;
 }

--- a/packages/ack_annotations/test/ack_model_test.dart
+++ b/packages/ack_annotations/test/ack_model_test.dart
@@ -73,16 +73,43 @@ void main() {
   test('AckField accepts a schema tear-off and a presence override', () {
     const inferred = AckField(schema: _customSchema);
     expect(inferred.schema, same(_customSchema));
-    expect(inferred.presence, AckFieldPresence.inferred);
+    expect(
+      // ignore: deprecated_member_use_from_same_package
+      inferred.presence,
+      // ignore: deprecated_member_use_from_same_package
+      AckFieldPresence.inferred,
+    );
 
+    // ignore: deprecated_member_use_from_same_package
     const optional = AckField(presence: AckFieldPresence.optional);
     expect(optional.schema, isNull);
-    expect(optional.presence, AckFieldPresence.optional);
-    expect(AckFieldPresence.values, const [
-      AckFieldPresence.inferred,
-      AckFieldPresence.required,
+    expect(
+      // ignore: deprecated_member_use_from_same_package
+      optional.presence,
+      // ignore: deprecated_member_use_from_same_package
       AckFieldPresence.optional,
-    ]);
+    );
+    expect(
+      // ignore: deprecated_member_use_from_same_package
+      AckFieldPresence.values,
+      const [
+        // ignore: deprecated_member_use_from_same_package
+        AckFieldPresence.inferred,
+        // ignore: deprecated_member_use_from_same_package
+        AckFieldPresence.required,
+        // ignore: deprecated_member_use_from_same_package
+        AckFieldPresence.optional,
+      ],
+    );
+  });
+
+  test('presence and null annotations are const', () {
+    const optional = Optional();
+    const required = Required();
+    const notNull = NotNull();
+    expect(optional, isA<Optional>());
+    expect(required, isA<Required>());
+    expect(notNull, isA<NotNull>());
   });
 
   test('constraint sugar annotations are const data', () {

--- a/packages/ack_generator/CHANGELOG.md
+++ b/packages/ack_generator/CHANGELOG.md
@@ -1,3 +1,20 @@
+## Unreleased
+
+### Added
+
+* Add `@Optional()`, `@Required()`, and `@NotNull()` class-first field
+  annotations. Key presence stays separate from JSON null acceptance.
+
+### Fixed
+
+* Derive class-first `copyWith` nullability from the constructor parameter type
+  so optional non-nullable codec fields compile and do not receive `null`.
+
+### Deprecated
+
+* Accept `@AckField(presence: ...)` during migration with a deprecation warning;
+  reject conflicts with `@Optional()` / `@Required()`.
+
 ## 1.3.0
 
 ### Changed

--- a/packages/ack_generator/README.md
+++ b/packages/ack_generator/README.md
@@ -144,7 +144,9 @@ getters. Classes, instance members, and local variables are rejected.
 
 `@AckModel()` annotates public, constructable `final class` declarations whose
 stored fields are final. Annotated sealed union bases remain supported, and
-their concrete branches must also be final. See the
+their concrete branches must also be final. Use `@Optional()` or `@Required()`
+to override inferred key presence, `@NotNull()` to reject JSON `null` without
+requiring the key, and `@AckField(schema: ...)` for custom codecs. See the
 [Model Code Generation guide](https://concepta.dev/documentation/ack/advanced/typesafe-schemas)
 for both directions, field inference, sealed unions, passthrough properties,
 and build configuration.

--- a/packages/ack_generator/lib/src/analyzer/class_model_graph_builder.dart
+++ b/packages/ack_generator/lib/src/analyzer/class_model_graph_builder.dart
@@ -7,6 +7,7 @@ import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
 import 'package:analyzer/dart/element/nullability_suffix.dart';
 import 'package:analyzer/dart/element/type.dart';
+import 'package:build/build.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:source_gen/source_gen.dart';
 
@@ -221,6 +222,18 @@ final class ClassModelGraphBuilder {
   );
   static const _uniqueItemsChecker = TypeChecker.typeNamed(
     annotations.UniqueItems,
+    inPackage: 'ack_annotations',
+  );
+  static const _optionalChecker = TypeChecker.typeNamed(
+    annotations.Optional,
+    inPackage: 'ack_annotations',
+  );
+  static const _requiredChecker = TypeChecker.typeNamed(
+    annotations.Required,
+    inPackage: 'ack_annotations',
+  );
+  static const _notNullChecker = TypeChecker.typeNamed(
+    annotations.NotNull,
     inPackage: 'ack_annotations',
   );
 
@@ -639,9 +652,11 @@ final class ClassModelGraphBuilder {
       }
       ownerByJsonKey[jsonKey] = field;
 
-      final nullable =
+      final dartNullable =
           futureType?.runtimeRef is AckNullableTypeRef ||
           _isNullable(field.type);
+      final rejectNull = _notNullChecker.hasAnnotationOfExact(field);
+      final acceptsNull = dartNullable && !rejectNull;
       final presence = _effectivePresence(
         field,
         parameter: parameter,
@@ -653,16 +668,20 @@ final class ClassModelGraphBuilder {
       schema = _applyPresence(
         schema,
         presence: presence,
-        nullable: nullable,
+        acceptsNull: acceptsNull,
         defaultCode: parameter?.defaultValueCode,
         defaultIsNull: parameter?.computeConstantValue()?.isNull ?? false,
       );
+      if (rejectNull) {
+        schema = '$schema.nullable(value: false)';
+      }
       nodes.add(
         AckFieldNode(
           dartName: name,
           jsonKey: jsonKey,
           presence: presence,
-          nullable: nullable,
+          nullable: dartNullable,
+          acceptsNull: acceptsNull,
           runtimeRef: futureType?.runtimeRef ?? _typeRef(field.type, field),
           schemaExpression: schema,
           defaultExpression: parameter?.defaultValueCode,
@@ -1530,42 +1549,85 @@ final class ClassModelGraphBuilder {
     required bool isDiscriminator,
   }) {
     final inferred = _fieldPresence(parameter);
-    final annotation = _ackFieldChecker.firstAnnotationOfExact(field);
-    if (annotation == null) return inferred;
-    final reader = ConstantReader(annotation);
-    final schemaMissing = reader.read('schema').isNull;
-    final presenceIndex = reader
-        .read('presence')
-        .objectValue
-        .getField('index')!
-        .toIntValue()!;
-    final presence = annotations.AckFieldPresence.values[presenceIndex];
-    if (schemaMissing && presence == annotations.AckFieldPresence.inferred) {
+    final hasOptional = _optionalChecker.hasAnnotationOfExact(field);
+    final hasRequired = _requiredChecker.hasAnnotationOfExact(field);
+    if (hasOptional && hasRequired) {
       throw InvalidGenerationSource(
-        '${field.enclosingElement.name}.${field.name} @AckField() is a no-op; '
-        'set schema or presence.',
+        '${field.enclosingElement.name}.${field.name} cannot combine '
+        '@Optional() and @Required().',
         element: field,
       );
     }
-    return switch (presence) {
-      annotations.AckFieldPresence.inferred => inferred,
-      annotations.AckFieldPresence.required => AckSchemaFieldPresence.required,
-      annotations.AckFieldPresence.optional => () {
-        final canBeOptional =
-            isDiscriminator ||
-            (parameter != null &&
-                (!parameter.isRequired || _isNullable(parameter.type)));
-        if (!canBeOptional) {
-          throw InvalidGenerationSource(
-            '${field.enclosingElement.name}.${field.name} cannot be '
-            '@AckField(presence: optional) because the constructor cannot '
-            'accept a missing value.',
-            element: field,
-          );
-        }
-        return AckSchemaFieldPresence.optional;
-      }(),
-    };
+
+    final annotation = _ackFieldChecker.firstAnnotationOfExact(field);
+    AckSchemaFieldPresence? legacyOverride;
+    if (annotation != null) {
+      final reader = ConstantReader(annotation);
+      final schemaMissing = reader.read('schema').isNull;
+      // AckFieldPresence index: 0 inferred, 1 required, 2 optional.
+      final presenceIndex = reader
+          .read('presence')
+          .objectValue
+          .getField('index')!
+          .toIntValue()!;
+      if (schemaMissing && presenceIndex == 0) {
+        throw InvalidGenerationSource(
+          '${field.enclosingElement.name}.${field.name} @AckField() is a '
+          'no-op; set schema or presence.',
+          element: field,
+        );
+      }
+      legacyOverride = switch (presenceIndex) {
+        0 => null,
+        1 => AckSchemaFieldPresence.required,
+        2 => AckSchemaFieldPresence.optional,
+        _ => throw StateError('Unknown AckFieldPresence index $presenceIndex.'),
+      };
+    }
+
+    final AckSchemaFieldPresence? annotationOverride;
+    if (hasOptional) {
+      annotationOverride = AckSchemaFieldPresence.optional;
+    } else if (hasRequired) {
+      annotationOverride = AckSchemaFieldPresence.required;
+    } else {
+      annotationOverride = null;
+    }
+
+    if (legacyOverride != null &&
+        annotationOverride != null &&
+        legacyOverride != annotationOverride) {
+      throw InvalidGenerationSource(
+        '${field.enclosingElement.name}.${field.name} has conflicting '
+        'presence declarations.',
+        element: field,
+      );
+    }
+
+    final override = annotationOverride ?? legacyOverride;
+    if (override == AckSchemaFieldPresence.optional) {
+      final canBeOptional =
+          isDiscriminator ||
+          (parameter != null &&
+              (!parameter.isRequired || _isNullable(parameter.type)));
+      if (!canBeOptional) {
+        throw InvalidGenerationSource(
+          '${field.enclosingElement.name}.${field.name} cannot be optional '
+          'because the constructor cannot accept a missing value.',
+          element: field,
+        );
+      }
+    }
+
+    if (legacyOverride != null) {
+      log.warning(
+        '${field.enclosingElement.name}.${field.name} uses '
+        '@AckField(presence: ...); use @Optional() or @Required() instead. '
+        'AckField.presence will be removed in 2.0.0.',
+      );
+    }
+
+    return override ?? inferred;
   }
 
   bool _isExactAdditionalPropertiesType(DartType type) {
@@ -1906,20 +1968,22 @@ final class ClassModelGraphBuilder {
   String _applyPresence(
     String schema, {
     required AckSchemaFieldPresence presence,
-    required bool nullable,
+    required bool acceptsNull,
     required String? defaultCode,
     required bool defaultIsNull,
   }) {
     return switch (presence) {
-      AckSchemaFieldPresence.defaulted when nullable && defaultIsNull =>
+      AckSchemaFieldPresence.defaulted when acceptsNull && defaultIsNull =>
         '$schema.optional().nullable()',
-      AckSchemaFieldPresence.defaulted when nullable =>
+      AckSchemaFieldPresence.defaulted when defaultIsNull =>
+        '$schema.optional()',
+      AckSchemaFieldPresence.defaulted when acceptsNull =>
         '$schema.nullable().withDefault($defaultCode)',
       AckSchemaFieldPresence.defaulted => '$schema.withDefault($defaultCode)',
-      AckSchemaFieldPresence.optional when nullable =>
+      AckSchemaFieldPresence.optional when acceptsNull =>
         '$schema.optional().nullable()',
       AckSchemaFieldPresence.optional => '$schema.optional()',
-      AckSchemaFieldPresence.required when nullable => '$schema.nullable()',
+      AckSchemaFieldPresence.required when acceptsNull => '$schema.nullable()',
       AckSchemaFieldPresence.required => schema,
     };
   }

--- a/packages/ack_generator/lib/src/builders/class_model_emitter.dart
+++ b/packages/ack_generator/lib/src/builders/class_model_emitter.dart
@@ -249,7 +249,7 @@ ${node.className} $function(Map<String, Object?> value) {
     final jsonHelper = jsonToHelperName(node.className);
     final requiredNulls = [
       for (final field in node.fields)
-        if (field.isRequired && field.nullable) field,
+        if (field.isRequired && field.acceptsNull) field,
     ];
     final discriminatorKey = node.discriminatorKey;
     final discriminatorValue = node.discriminatorValue;

--- a/packages/ack_generator/lib/src/builders/data_class_emitter.dart
+++ b/packages/ack_generator/lib/src/builders/data_class_emitter.dart
@@ -36,7 +36,6 @@ final class AckDataClassEmitter {
       if (includeValueMembers) ...[
         copyWithMethod(
           className: className,
-          fields: stored,
           constructorParameters: constructorParameters,
           castSelf: true,
         ),
@@ -45,14 +44,8 @@ final class AckDataClassEmitter {
       ],
       jsonMembers(className: className, facadeName: facadeName),
     ];
-    final storedByField = {for (final field in stored) field.dartName: field};
     final needsCopyWithSentinel =
-        includeValueMembers &&
-        constructorParameters.any((parameter) {
-          final field = storedByField[parameter.fieldName];
-
-          return field != null && _usesCopyWithSentinel(field);
-        });
+        includeValueMembers && constructorParameters.any(_usesCopyWithSentinel);
     final sentinelType = ackCopyWithUnsetTypeName(className);
 
     return '''
@@ -64,28 +57,20 @@ mixin ${'_\$${className}Ack'} {
 
   String copyWithMethod({
     required String className,
-    required List<AckFieldNode> fields,
     required List<AckConstructorParameter> constructorParameters,
     bool castSelf = false,
   }) {
-    final byField = {for (final field in fields) field.dartName: field};
     final receiver = castSelf ? 'self' : 'this';
     final parameters = [
       for (final parameter in constructorParameters)
-        if (_usesCopyWithSentinel(
-          byField[parameter.fieldName] ?? _synthetic(parameter),
-        ))
+        if (_usesCopyWithSentinel(parameter))
           'Object? ${parameter.name} = $_copyWithUnset'
         else
-          '${_copyWithType(byField[parameter.fieldName] ?? _synthetic(parameter))} ${parameter.name}',
+          '${_copyWithType(parameter)} ${parameter.name}',
     ];
     final arguments = [
       for (final parameter in constructorParameters)
-        _copyWithArgument(
-          parameter,
-          byField[parameter.fieldName] ?? _synthetic(parameter),
-          receiver,
-        ),
+        _copyWithArgument(parameter, receiver),
     ];
     final parameterList = parameters.isEmpty
         ? ''
@@ -183,42 +168,25 @@ ${_ack('SchemaResult')}<Map<String, Object?>> safeToJson() =>
     $facadeName.safeEncode(this as $className);''';
   }
 
-  String fieldDartType(AckFieldNode field) {
-    final base = _type(field.runtimeRef);
-    if (field.isRequired && !field.nullable) return base;
-    return base.endsWith('?') ? base : '$base?';
-  }
-
-  String _copyWithType(AckFieldNode field) {
-    final type = fieldDartType(field);
-    return type.endsWith('?') ? type : '$type?';
-  }
+  String _copyWithType(AckConstructorParameter parameter) =>
+      '${_type(parameter.typeRef)}?';
 
   String _copyWithArgument(
     AckConstructorParameter parameter,
-    AckFieldNode field,
     String receiver,
   ) {
-    final replacement = _usesCopyWithSentinel(field)
+    final replacement = _usesCopyWithSentinel(parameter)
         ? 'identical(${parameter.name}, $_copyWithUnset) '
               '? $receiver.${parameter.fieldName} '
-              ': ${parameter.name} as ${fieldDartType(field)}'
+              ': ${parameter.name} as ${_type(parameter.typeRef)}'
         : '${parameter.name} ?? $receiver.${parameter.fieldName}';
     return parameter.kind == AckConstructorParameterKind.named
         ? '${parameter.name}: $replacement'
         : replacement;
   }
 
-  bool _usesCopyWithSentinel(AckFieldNode field) =>
-      fieldDartType(field).endsWith('?');
-
-  AckFieldNode _synthetic(AckConstructorParameter parameter) => AckFieldNode(
-    dartName: parameter.fieldName,
-    jsonKey: parameter.fieldName,
-    presence: AckSchemaFieldPresence.required,
-    nullable: parameter.typeRef is AckNullableTypeRef,
-    runtimeRef: parameter.typeRef,
-  );
+  bool _usesCopyWithSentinel(AckConstructorParameter parameter) =>
+      parameter.typeRef is AckNullableTypeRef;
 
   String _equals(String left, String right) =>
       '${_ack('deepEquals')}($left, $right)';

--- a/packages/ack_generator/lib/src/builders/data_class_emitter.dart
+++ b/packages/ack_generator/lib/src/builders/data_class_emitter.dart
@@ -171,10 +171,7 @@ ${_ack('SchemaResult')}<Map<String, Object?>> safeToJson() =>
   String _copyWithType(AckConstructorParameter parameter) =>
       '${_type(parameter.typeRef)}?';
 
-  String _copyWithArgument(
-    AckConstructorParameter parameter,
-    String receiver,
-  ) {
+  String _copyWithArgument(AckConstructorParameter parameter, String receiver) {
     final replacement = _usesCopyWithSentinel(parameter)
         ? 'identical(${parameter.name}, $_copyWithUnset) '
               '? $receiver.${parameter.fieldName} '

--- a/packages/ack_generator/lib/src/models/schema_model_graph.dart
+++ b/packages/ack_generator/lib/src/models/schema_model_graph.dart
@@ -21,10 +21,10 @@ final class AckSchemaId {
 
 /// Input-presence semantics for an object field in the normalized graph.
 ///
-/// This is distinct from the public `AckFieldPresence` annotation, which only
-/// expresses an override (`inferred` / `required` / `optional`). Presence and
-/// nullability stay separate: a field can be required and nullable, optional
-/// and non-nullable, or defaulted by the schema.
+/// This is distinct from the public `@Optional()` / `@Required()` annotations
+/// and the deprecated `AckFieldPresence` override. Presence and nullability
+/// stay separate: a field can be required and nullable, optional and
+/// non-nullable, or defaulted by the schema.
 enum AckSchemaFieldPresence { required, optional, defaulted }
 
 /// How an object model treats undeclared properties.
@@ -138,15 +138,22 @@ final class AckFieldNode {
     required this.presence,
     required this.nullable,
     required this.runtimeRef,
+    bool? acceptsNull,
     this.description,
     this.schemaExpression,
     this.defaultExpression,
-  });
+  }) : acceptsNull = acceptsNull ?? nullable;
 
   final String dartName;
   final String jsonKey;
   final AckSchemaFieldPresence presence;
   final bool nullable;
+
+  /// Whether a present JSON value may be `null`.
+  ///
+  /// This is independent of [nullable] Dart storage and of key [presence].
+  /// `@NotNull()` sets it to false while leaving the Dart type unchanged.
+  final bool acceptsNull;
   final AckInferRef runtimeRef;
   final String? description;
 

--- a/packages/ack_generator/test/integration/class_first_runtime_build_test.dart
+++ b/packages/ack_generator/test/integration/class_first_runtime_build_test.dart
@@ -219,7 +219,7 @@ final class Loose with _$LooseAck {
 final class Normalized with _$NormalizedAck {
   const Normalized(String? value) : value = value ?? '';
 
-  @AckField(presence: AckFieldPresence.optional)
+  @Optional()
   final String value;
 }
 
@@ -259,6 +259,98 @@ final class ImmutableCollections with _$ImmutableCollectionsAck {
   final Set<String> labels;
   @AckField(schema: groupsSchema)
   final Map<String, List<String>> groups;
+}
+
+@AckModel()
+final class Example with _$ExampleAck {
+  const Example({this.label, this.title});
+
+  @Optional()
+  @NotNull()
+  final String? label;
+
+  @Optional()
+  @NotNull()
+  @NotEmpty()
+  final String? title;
+
+  static final fromJson = ExampleSchema.fromJson;
+}
+
+@AckModel()
+final class ExampleHolder with _$ExampleHolderAck {
+  const ExampleHolder({required this.example});
+
+  final Example example;
+}
+
+@AckModel()
+final class OptionalNullable with _$OptionalNullableAck {
+  const OptionalNullable({this.note});
+
+  @Optional()
+  final String? note;
+}
+
+@AckModel()
+final class InferredNotNull with _$InferredNotNullAck {
+  const InferredNotNull({this.label});
+
+  @NotNull()
+  final String? label;
+}
+
+AckSchema<String, String> nullableNameSchema() => Ack.string().nullable();
+
+@AckModel()
+final class OverrideNotNull with _$OverrideNotNullAck {
+  const OverrideNotNull({this.name});
+
+  @NotNull()
+  @AckField(schema: nullableNameSchema)
+  final String? name;
+}
+
+@AckModel()
+final class RequiredNotNull with _$RequiredNotNullAck {
+  const RequiredNotNull({this.value});
+
+  @Required()
+  @NotNull()
+  final String? value;
+}
+
+final class ParameterEntry {
+  const ParameterEntry(this.value);
+  final String value;
+}
+
+AckSchema<Map<String, Object?>, Map<String, ParameterEntry>>
+parameterMapSchema() =>
+    Ack.object({}, additionalProperties: true).codec<Map<String, ParameterEntry>>(
+      decode: (value) => {
+        for (final entry in value.entries)
+          entry.key: ParameterEntry(entry.value! as String),
+      },
+      encode: (value) => {
+        for (final entry in value.entries) entry.key: entry.value.value,
+      },
+    );
+
+@AckModel()
+final class CapabilityBinding with _$CapabilityBindingAck {
+  CapabilityBinding({
+    required this.name,
+    Map<String, ParameterEntry> parameters = const {},
+  }) : parameters = Map.unmodifiable(parameters);
+
+  final String name;
+
+  @Optional()
+  @AckField(schema: parameterMapSchema)
+  final Map<String, ParameterEntry> parameters;
+
+  static final fromJson = CapabilityBindingSchema.fromJson;
 }
 
 @AckModel(discriminatorKey: 'type')
@@ -476,6 +568,123 @@ void main() {
     );
   });
 
+  test('optional not-null fields omit keys and reject explicit null', () {
+    expect(ExampleSchema.parse({}).label, isNull);
+    expect(ExampleSchema.parse({'label': 'hello'}).label, 'hello');
+    expect(ExampleSchema.safeParse({'label': null}).isFail, isTrue);
+    expect(
+      () => ExampleSchema.parse({'label': null}),
+      throwsA(isA<AckException>()),
+    );
+    expect(Example.fromJson({}).label, isNull);
+    expect(Example.fromJson({'label': 'hello'}).label, 'hello');
+    expect(Example().toJson(), {});
+    expect(Example(label: 'hello').toJson(), {'label': 'hello'});
+    expect(ExampleSchema.encode(Example()), {});
+    expect(ExampleSchema.safeEncode(Example()).isOk, isTrue);
+    expect(
+      ExampleSchema.encode(Example(label: 'hello')),
+      {'label': 'hello'},
+    );
+    expect(Example(label: 'hello').copyWith(label: null).toJson(), {});
+
+    final jsonSchema = ExampleSchema.toJsonSchema();
+    expect(jsonSchema['required'] ?? const <Object?>[], isNot(contains('label')));
+    expect(
+      (jsonSchema['properties'] as Map)['label'],
+      isNot(containsPair('type', ['string', 'null'])),
+    );
+    expect(
+      ((jsonSchema['properties'] as Map)['label'] as Map)['type'],
+      'string',
+    );
+    expect(
+      ExampleSchema.toSchemaModel().toJsonSchema(),
+      ExampleSchema.toJsonSchema(),
+    );
+
+    expect(ExampleHolderSchema.parse({'example': {}}).example.label, isNull);
+    expect(
+      ExampleHolderSchema.safeParse({
+        'example': {'label': null},
+      }).isFail,
+      isTrue,
+    );
+    expect(ExampleHolderSchema.parse({'example': {}}).toJson(), {
+      'example': {},
+    });
+    expect(
+      ExampleHolderSchema.toSchemaModel().toJsonSchema(),
+      ExampleHolderSchema.toJsonSchema(),
+    );
+  });
+
+  test('optional nullable fields still accept explicit JSON null', () {
+    expect(OptionalNullableSchema.parse({}).note, isNull);
+    expect(OptionalNullableSchema.parse({'note': null}).note, isNull);
+    expect(OptionalNullableSchema.parse({'note': 'n'}).note, 'n');
+  });
+
+  test('NotNull alone on an inferred optional String? rejects JSON null', () {
+    expect(InferredNotNullSchema.parse({}).label, isNull);
+    expect(InferredNotNullSchema.parse({'label': 'hello'}).label, 'hello');
+    expect(InferredNotNullSchema.safeParse({'label': null}).isFail, isTrue);
+    expect(InferredNotNull().toJson(), {});
+  });
+
+  test('NotNull wins over a nullable AckField schema override', () {
+    expect(OverrideNotNullSchema.parse({}).name, isNull);
+    expect(OverrideNotNullSchema.parse({'name': 'ada'}).name, 'ada');
+    expect(OverrideNotNullSchema.safeParse({'name': null}).isFail, isTrue);
+    expect(OverrideNotNull().toJson(), {});
+  });
+
+  test('Required plus NotNull rejects JSON null and does not emit it', () {
+    expect(RequiredNotNullSchema.safeParse({}).isFail, isTrue);
+    expect(RequiredNotNullSchema.parse({'value': 'ok'}).value, 'ok');
+    expect(RequiredNotNullSchema.safeParse({'value': null}).isFail, isTrue);
+    expect(RequiredNotNullSchema.safeEncode(RequiredNotNull()).isFail, isTrue);
+    expect(
+      RequiredNotNullSchema.encode(const RequiredNotNull(value: 'ok')),
+      {'value': 'ok'},
+    );
+  });
+
+  test('NotEmpty still rejects an empty supplied optional not-null value', () {
+    expect(ExampleSchema.safeParse({'title': ''}).isFail, isTrue);
+    expect(ExampleSchema.parse({'title': 'ok'}).title, 'ok');
+    expect(ExampleSchema.parse({}).title, isNull);
+    expect(ExampleSchema.safeParse({'title': null}).isFail, isTrue);
+  });
+
+  test('optional non-nullable map codecs default and copy without null', () {
+    expect(CapabilityBindingSchema.parse({'name': 'bind'}).parameters, isEmpty);
+    expect(
+      CapabilityBindingSchema.parse({
+        'name': 'bind',
+        'parameters': {'a': 'v'},
+      }).parameters['a']!.value,
+      'v',
+    );
+    expect(
+      CapabilityBindingSchema.safeParse({
+        'name': 'bind',
+        'parameters': null,
+      }).isFail,
+      isTrue,
+    );
+
+    final binding = CapabilityBinding(name: 'bind');
+    expect(binding.copyWith().parameters, isEmpty);
+    expect(
+      binding.copyWith(
+        parameters: {'a': const ParameterEntry('v')},
+      ).parameters['a']!.value,
+      'v',
+    );
+    expect(binding.copyWith().toJson(), {'name': 'bind', 'parameters': {}});
+  });
+
   test('sealed unions use super parameters and discriminator rules', () {
     final cat = PetSchema.parse({'type': 'cat', 'id': 'c1', 'lives': 9});
     expect(cat, isA<Cat>());
@@ -560,6 +769,14 @@ void main() {
         expect(
           generated['lib/models.ack.dart'],
           isNot(contains('final profileSchema =')),
+        );
+        expect(
+          generated['lib/models.ack.dart'],
+          contains('parameters: parameters ?? self.parameters'),
+        );
+        expect(
+          generated['lib/models.ack.dart'],
+          isNot(contains('parameters as Map<String, ParameterEntry>?')),
         );
 
         _expectSuccess(

--- a/packages/ack_generator/test/integration/class_model_emitter_test.dart
+++ b/packages/ack_generator/test/integration/class_model_emitter_test.dart
@@ -533,7 +533,9 @@ final class CapabilityBinding with _\$CapabilityBindingAck {
         outputs: {
           'test_pkg|lib/fields.ack.dart': decodedMatches(
             allOf([
-              contains("'label': Ack.string().optional().nullable(value: false)"),
+              contains(
+                "'label': Ack.string().optional().nullable(value: false)",
+              ),
               contains("'nickname': Ack.string().optional().nullable()"),
               isNot(
                 contains(

--- a/packages/ack_generator/test/integration/class_model_emitter_test.dart
+++ b/packages/ack_generator/test/integration/class_model_emitter_test.dart
@@ -425,6 +425,145 @@ final class Account with _\$AccountAck {
     },
   );
 
+  test(
+    'field presence annotations compose independently of nullability',
+    () async {
+      await _build(
+        {
+          'fields.dart':
+              '''
+$_imports
+part 'fields.ack.dart';
+part 'fields.ack.g.dart';
+
+@AckModel()
+final class Example with _\$ExampleAck {
+  const Example({this.label, this.nickname, this.title});
+
+  @Optional()
+  @NotNull()
+  final String? label;
+
+  @Optional()
+  final String? nickname;
+
+  @Optional()
+  @NotNull()
+  @NotEmpty()
+  final String? title;
+}
+
+@AckModel()
+final class InferredNotNull with _\$InferredNotNullAck {
+  const InferredNotNull({this.label});
+
+  @NotNull()
+  final String? label;
+}
+
+AckSchema<String, String> nullableNameSchema() => Ack.string().nullable();
+
+@AckModel()
+final class OverrideNotNull with _\$OverrideNotNullAck {
+  const OverrideNotNull({this.name});
+
+  @NotNull()
+  @AckField(schema: nullableNameSchema)
+  final String? name;
+}
+
+@AckModel()
+final class RequiredNotNull with _\$RequiredNotNullAck {
+  const RequiredNotNull({this.value});
+
+  @Required()
+  @NotNull()
+  final String? value;
+}
+
+@AckModel()
+final class Forced with _\$ForcedAck {
+  const Forced({this.summary});
+
+  @Required()
+  final String? summary;
+}
+
+@AckModel()
+final class LegacyOptional with _\$LegacyOptionalAck {
+  const LegacyOptional({this.note});
+
+  @AckField(presence: AckFieldPresence.optional)
+  final String? note;
+}
+
+final class ParameterEntry {
+  const ParameterEntry(this.value);
+  final String value;
+}
+
+AckSchema<Map<String, Object?>, Map<String, ParameterEntry>>
+parameterMapSchema() =>
+    Ack.object({}, additionalProperties: true)
+        .codec<Map<String, ParameterEntry>>(
+          decode: (value) => {
+            for (final entry in value.entries)
+              entry.key: ParameterEntry(entry.value! as String),
+          },
+          encode: (value) => {
+            for (final entry in value.entries) entry.key: entry.value.value,
+          },
+        );
+
+@AckModel()
+final class CapabilityBinding with _\$CapabilityBindingAck {
+  CapabilityBinding({
+    required this.name,
+    Map<String, ParameterEntry> parameters = const {},
+  }) : parameters = Map.unmodifiable(parameters);
+
+  final String name;
+
+  @Optional()
+  @AckField(schema: parameterMapSchema)
+  final Map<String, ParameterEntry> parameters;
+}
+''',
+        },
+        outputs: {
+          'test_pkg|lib/fields.ack.dart': decodedMatches(
+            allOf([
+              contains("'label': Ack.string().optional().nullable(value: false)"),
+              contains("'nickname': Ack.string().optional().nullable()"),
+              isNot(
+                contains(
+                  "'nickname': Ack.string().optional().nullable(value: false)",
+                ),
+              ),
+              contains(
+                "'title': Ack.string().notEmpty().optional().nullable(value: false)",
+              ),
+              contains(
+                'nullableNameSchema().optional().nullable(value: false)',
+              ),
+              contains("'value': Ack.string().nullable(value: false)"),
+              isNot(contains("'value': Ack.string().optional()")),
+              contains("'summary': Ack.string().nullable()"),
+              contains("'note': Ack.string().optional().nullable()"),
+              contains("'parameters': parameterMapSchema().optional()"),
+              isNot(contains('parameterMapSchema().optional().nullable(')),
+              contains('Map<String, ParameterEntry>? parameters'),
+              contains('parameters: parameters ?? self.parameters'),
+              isNot(contains('parameters as Map<String, ParameterEntry>?')),
+              contains('Object? label = _ackCopyWithUnset'),
+              contains(': label as String?'),
+            ]),
+          ),
+        },
+      );
+    },
+  );
+
   test('qualifies facade APIs through a prefixed Ack import', () async {
     await _build(
       {

--- a/packages/ack_generator/test/integration/class_model_graph_test.dart
+++ b/packages/ack_generator/test/integration/class_model_graph_test.dart
@@ -43,9 +43,7 @@ Future<void> _expectWarning(String body, List<String> messages) async {
     {'test_pkg|lib/model.dart': '$_head\n$body'},
     generateFor: const {'test_pkg|lib/model.dart'},
     readerWriter: readerWriter,
-    outputs: {
-      'test_pkg|lib/model.ack.dart': decodedMatches(contains('mixin')),
-    },
+    outputs: {'test_pkg|lib/model.ack.dart': decodedMatches(contains('mixin'))},
     onLog: (LogRecord log) {
       if (log.level.name != 'WARNING') return;
       for (final message in messages) {
@@ -1086,10 +1084,11 @@ final class User with _\$UserAck {
     );
   });
 
-  test('warns when matching legacy and new presence declarations coexist',
-      () async {
-    await _expectWarning(
-      '''
+  test(
+    'warns when matching legacy and new presence declarations coexist',
+    () async {
+      await _expectWarning(
+        '''
 @AckModel()
 final class User with _\$UserAck {
   const User({this.name});
@@ -1099,9 +1098,10 @@ final class User with _\$UserAck {
   final String? name;
 }
 ''',
-      ['User.name', '@AckField(presence:', '2.0.0'],
-    );
-  });
+        ['User.name', '@AckField(presence:', '2.0.0'],
+      );
+    },
+  );
 
   test('rejects an unmapped constructor parameter', () async {
     await _expectFailure(

--- a/packages/ack_generator/test/integration/class_model_graph_test.dart
+++ b/packages/ack_generator/test/integration/class_model_graph_test.dart
@@ -34,6 +34,28 @@ Future<void> _expectFailure(
   expect(seen, containsAll(messages));
 }
 
+Future<void> _expectWarning(String body, List<String> messages) async {
+  final readerWriter = TestReaderWriter(rootPackage: 'test_pkg');
+  await readerWriter.testing.loadIsolateSources();
+  final seen = <String>{};
+  await testBuilder(
+    ackModelBuilder(BuilderOptions.empty),
+    {'test_pkg|lib/model.dart': '$_head\n$body'},
+    generateFor: const {'test_pkg|lib/model.dart'},
+    readerWriter: readerWriter,
+    outputs: {
+      'test_pkg|lib/model.ack.dart': decodedMatches(contains('mixin')),
+    },
+    onLog: (LogRecord log) {
+      if (log.level.name != 'WARNING') return;
+      for (final message in messages) {
+        if (log.message.contains(message)) seen.add(message);
+      }
+    },
+  );
+  expect(seen, containsAll(messages));
+}
+
 const _head = '''
 import 'package:ack/ack.dart';
 import 'package:ack_annotations/ack_annotations.dart';
@@ -1001,6 +1023,85 @@ final class User with _\$UserAck {
       );
     },
   );
+
+  test('rejects @Optional() on a required constructor parameter', () async {
+    await _expectFailure(
+      '''
+@AckModel()
+final class User with _\$UserAck {
+  const User({required this.name});
+
+  @Optional()
+  final String name;
+}
+''',
+      ['User.name', 'optional', 'constructor'],
+    );
+  });
+
+  test('rejects combining @Optional() and @Required()', () async {
+    await _expectFailure(
+      '''
+@AckModel()
+final class User with _\$UserAck {
+  const User({this.name});
+
+  @Optional()
+  @Required()
+  final String? name;
+}
+''',
+      ['User.name', '@Optional()', '@Required()'],
+    );
+  });
+
+  test('rejects conflicting legacy and new presence declarations', () async {
+    await _expectFailure(
+      '''
+@AckModel()
+final class User with _\$UserAck {
+  const User({this.name});
+
+  @Optional()
+  @AckField(presence: AckFieldPresence.required)
+  final String? name;
+}
+''',
+      ['User.name', 'conflicting', 'presence'],
+    );
+  });
+
+  test('warns when legacy AckField presence is used', () async {
+    await _expectWarning(
+      '''
+@AckModel()
+final class User with _\$UserAck {
+  const User({this.name});
+
+  @AckField(presence: AckFieldPresence.optional)
+  final String? name;
+}
+''',
+      ['User.name', '@AckField(presence:', '@Optional()', '2.0.0'],
+    );
+  });
+
+  test('warns when matching legacy and new presence declarations coexist',
+      () async {
+    await _expectWarning(
+      '''
+@AckModel()
+final class User with _\$UserAck {
+  const User({this.name});
+
+  @Optional()
+  @AckField(presence: AckFieldPresence.optional)
+  final String? name;
+}
+''',
+      ['User.name', '@AckField(presence:', '2.0.0'],
+    );
+  });
 
   test('rejects an unmapped constructor parameter', () async {
     await _expectFailure(


### PR DESCRIPTION
## Summary
- Add `@Optional()`, `@Required()`, and `@NotNull()` so class-first models can override JSON key presence independently of whether a present value may be `null`, and deprecate `AckField.presence` for removal in 2.0.0.
- Fix generated `copyWith` so optional non-nullable codec fields follow the constructor type and no longer receive `null`.

## Validation
- `dart test` and `dart analyze --fatal-infos` in `packages/ack_annotations` — passed
- `dart analyze --fatal-infos` plus `class_model_emitter_test`, `class_model_graph_test`, and `class_first_runtime_build_test` in `packages/ack_generator` — passed

## Risk and rollout
- Legacy `@AckField(presence: ...)` still generates with a deprecation warning. This does not complete the Stargate migration: `Object?` fields and omitting empty defaults remain out of scope.
