### PR TITLE
chore(release): prepare coordinated Ack 1.4.0 release

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -24,7 +24,7 @@ env:
   # The published release that every public API is compared against. Raise it
   # after each published version. `dart_apitool` compares the declared version
   # against the change severity, so a breaking change requires a major bump.
-  API_BASELINE_VERSION: '1.2.0'
+  API_BASELINE_VERSION: '1.3.0'
   # The lowest SDK versions that packages/*/pubspec.yaml accept.
   MINIMUM_DART_VERSION: '3.9.0'
   MINIMUM_FLUTTER_VERSION: '3.35.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.4.0
+
+* Add `@Optional()`, `@Required()`, and `@NotNull()` class-first field
+  annotations so JSON key presence stays independent of null acceptance.
+* Deprecate `AckField.presence` and `AckFieldPresence` for removal in 2.0.0.
+* Fix class-first `copyWith` so optional non-nullable codec fields follow the
+  constructor type and do not receive `null`.
+* Align all six publishable packages at 1.4.0; compare public APIs against 1.3.0.
+
 ## 1.3.0
 
 * Add `ack_mcp_dart` for MCP tool input schemas, defaults, codecs, refinements,

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -9,8 +9,9 @@ environment. A release-preparation PR does not publish anything.
 
 Use SemVer for the combined public API: patch for compatible fixes, minor for
 new compatible features/packages, and major when any stable public API breaks.
-The next release is **1.3.0**, introducing `ack_mcp_dart`; the existing five
-packages have no runtime or API changes since 1.2.0.
+The next release is **1.4.0**, adding `@Optional()`, `@Required()`, and
+`@NotNull()` plus the class-first `copyWith` fix. The runtime, Firebase,
+JSON Schema, and MCP packages have no API changes since 1.3.0.
 
 Melos **8.7** is configured with `mode: fixed` and `workspaceTag: true`, matching
 this repository's release-tag verifier. `smartDependents: true` preserves
@@ -42,7 +43,7 @@ References: [Melos versioning](https://melos.invertase.dev/commands/version),
 3. Preview/prepare a coordinated version without creating commits or tags:
 
    ```sh
-   dart run melos version --manual-version=ack:1.3.0 --yes --no-git-commit-version
+   dart run melos version --manual-version=ack:1.4.0 --yes --no-git-commit-version
    ```
 
    Use the named flag, not a positional package argument: the positional form
@@ -55,15 +56,15 @@ References: [Melos versioning](https://melos.invertase.dev/commands/version),
    unreleased notes into the new section, preserving every published section.
    Update installation snippets to match each package's version.
 5. Set `API_BASELINE_VERSION` in `.github/workflows/preflight.yml` to the latest
-   published release (currently `1.2.0`). Record a new package's actual first
+   published release (currently `1.3.0`). Record a new package's actual first
    release in `ackPackageFirstReleases` in `scripts/src/workspace_packages.dart`;
-   checks skip only older baselines. `ack_mcp_dart` first releases at 1.3.0.
+   checks skip only older baselines. `ack_mcp_dart` first released at 1.3.0.
 6. Validate the complete release:
 
    ```sh
-   dart scripts/verify_release_tag.dart v1.3.0 --skip-ancestry
+   dart scripts/verify_release_tag.dart v1.4.0 --skip-ancestry
    dart run melos run ci
-   dart scripts/api_check.dart 1.2.0
+   dart scripts/api_check.dart 1.3.0
    dart scripts/publish_dry_run.dart
    dart run melos run validate-jsonschema:batch
    ```
@@ -114,9 +115,9 @@ After the release commit's CI/preflight succeeds and first-package setup is done
 ```sh
 git fetch origin main --tags
 # Use the exact reviewed release merge commit, not an arbitrary later main head.
-git tag -a v1.3.0 <release-merge-sha> -m 'Ack 1.3.0'
-dart scripts/verify_release_tag.dart v1.3.0
-git push origin v1.3.0
+git tag -a v1.4.0 <release-merge-sha> -m 'Ack 1.4.0'
+dart scripts/verify_release_tag.dart v1.4.0
+git push origin v1.4.0
 ```
 
 Pushing the tag triggers `.github/workflows/release.yml`; there is no Melos
@@ -142,4 +143,4 @@ or republish different contents under an existing version.
 
 After all six exact versions are visible, create the GitHub Release from the
 existing tag using the prepared release notes. Before the first subsequent code
-change, begin a new unreleased changelog section instead of editing 1.3.0 notes.
+change, begin a new unreleased changelog section instead of editing 1.4.0 notes.

--- a/packages/ack/CHANGELOG.md
+++ b/packages/ack/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.0
+
+### Changed
+
+* Align with the coordinated Ack 1.4 release adding class-first field
+  annotations; this package has no runtime or public API changes from 1.3.0.
+
 ## 1.3.0
 
 ### Changed

--- a/packages/ack/pubspec.yaml
+++ b/packages/ack/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack
 description: Schema validation and bidirectional codecs for Dart and Flutter
-version: 1.3.0
+version: 1.4.0
 repository: https://github.com/conceptadev/ack
 issue_tracker: https://github.com/conceptadev/ack/issues
 homepage: https://concepta.dev/ack

--- a/packages/ack_annotations/CHANGELOG.md
+++ b/packages/ack_annotations/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.4.0
 
 ### Added
 

--- a/packages/ack_annotations/README.md
+++ b/packages/ack_annotations/README.md
@@ -9,10 +9,10 @@ retained for Ack 1.1 extension-type compatibility.
 ```yaml
 dependencies:
   ack: ^1.2.0
-  ack_annotations: ^1.3.0
+  ack_annotations: ^1.4.0
 
 dev_dependencies:
-  ack_generator: ^1.3.0
+  ack_generator: ^1.4.0
   build_runner: ^2.4.0
 ```
 

--- a/packages/ack_annotations/pubspec.yaml
+++ b/packages/ack_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_annotations
 description: Annotations for Ack schema-first models and class-first schema generation
-version: 1.3.0
+version: 1.4.0
 repository: https://github.com/conceptadev/ack
 resolution: workspace
 topics:

--- a/packages/ack_firebase_ai/CHANGELOG.md
+++ b/packages/ack_firebase_ai/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.0
+
+### Changed
+
+* Align with the coordinated Ack 1.4 release; this package has no runtime or
+  public API changes from 1.3.0.
+
 ## 1.3.0
 
 ### Changed

--- a/packages/ack_firebase_ai/README.md
+++ b/packages/ack_firebase_ai/README.md
@@ -24,7 +24,7 @@ Always validate model output with the same ACK schema after generation. Firebase
 ```yaml
 dependencies:
   ack: ^1.2.0
-  ack_firebase_ai: ^1.3.0
+  ack_firebase_ai: ^1.4.0
   firebase_ai: ^3.12.2
 ```
 

--- a/packages/ack_firebase_ai/pubspec.yaml
+++ b/packages/ack_firebase_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_firebase_ai
 description: Firebase AI (Gemini) schema converter for the Ack validation library
-version: 1.3.0
+version: 1.4.0
 repository: https://github.com/conceptadev/ack
 issue_tracker: https://github.com/conceptadev/ack/issues
 resolution: workspace

--- a/packages/ack_generator/CHANGELOG.md
+++ b/packages/ack_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.4.0
 
 ### Added
 

--- a/packages/ack_generator/pubspec.yaml
+++ b/packages/ack_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_generator
 description: Generates immutable models from Ack schemas and validated schemas from Dart classes
-version: 1.3.0
+version: 1.4.0
 repository: https://github.com/conceptadev/ack
 issue_tracker: https://github.com/conceptadev/ack/issues
 resolution: workspace
@@ -29,7 +29,7 @@ dependencies:
 
   # Ack packages (versions are overridden locally by Melos)
   ack: ^1.2.0
-  ack_annotations: ^1.2.0
+  ack_annotations: ^1.4.0
 
 dev_dependencies:
   build_runner: ^2.1.7

--- a/packages/ack_json_schema_builder/CHANGELOG.md
+++ b/packages/ack_json_schema_builder/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.0
+
+### Changed
+
+* Align with the coordinated Ack 1.4 release; this package has no runtime or
+  public API changes from 1.3.0.
+
 ## 1.3.0
 
 ### Changed

--- a/packages/ack_json_schema_builder/README.md
+++ b/packages/ack_json_schema_builder/README.md
@@ -13,7 +13,7 @@ Converts ACK schemas to json_schema_builder format via `.toJsonSchemaBuilder()`.
 ```yaml
 dependencies:
   ack: ^1.2.0
-  ack_json_schema_builder: ^1.3.0
+  ack_json_schema_builder: ^1.4.0
   json_schema_builder: ^0.1.3
 ```
 

--- a/packages/ack_json_schema_builder/pubspec.yaml
+++ b/packages/ack_json_schema_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_json_schema_builder
 description: JSON Schema Builder converter for the Ack validation library
-version: 1.3.0
+version: 1.4.0
 repository: https://github.com/conceptadev/ack
 issue_tracker: https://github.com/conceptadev/ack/issues
 resolution: workspace

--- a/packages/ack_mcp_dart/CHANGELOG.md
+++ b/packages/ack_mcp_dart/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.0
+
+### Changed
+
+* Align with the coordinated Ack 1.4 release; this package has no runtime or
+  public API changes from 1.3.0.
+
 ## 1.3.0
 
 ### Added

--- a/packages/ack_mcp_dart/README.md
+++ b/packages/ack_mcp_dart/README.md
@@ -16,7 +16,7 @@ Transport, negotiation, cancellation, and lifecycle remain in `mcp_dart`.
 ```yaml
 dependencies:
   ack: ^1.2.0
-  ack_mcp_dart: ^1.3.0
+  ack_mcp_dart: ^1.4.0
   mcp_dart: ^2.4.2
 ```
 

--- a/packages/ack_mcp_dart/example/example.dart
+++ b/packages/ack_mcp_dart/example/example.dart
@@ -18,7 +18,7 @@ final searchInput = Ack.object({
 
 Future<void> main() async {
   final server = McpServer(
-    const Implementation(name: 'ack-search-example', version: '1.3.0'),
+    const Implementation(name: 'ack-search-example', version: '1.4.0'),
   );
   server.registerAckTool(
     'search',

--- a/packages/ack_mcp_dart/pubspec.yaml
+++ b/packages/ack_mcp_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_mcp_dart
 description: MCP tool schemas and typed argument validation for Ack and mcp_dart
-version: 1.3.0
+version: 1.4.0
 repository: https://github.com/conceptadev/ack
 issue_tracker: https://github.com/conceptadev/ack/issues
 resolution: workspace


### PR DESCRIPTION
## Summary
- Prepare the coordinated Ack **1.4.0** release for the field-annotation follow-up: `@Optional()`, `@Required()`, `@NotNull()`, `AckField.presence` deprecation, and the class-first `copyWith` fix.
- Lockstep all six publishable packages, raise `ack_generator`'s `ack_annotations` floor to `^1.4.0`, and compare public APIs against published 1.3.0.

## Validation
- `dart scripts/verify_release_tag.dart v1.4.0 --skip-ancestry` — passed
- `dart test test/scripts/release_documentation_test.dart test/scripts/release_changelog_test.dart test/scripts/verify_release_tag_test.dart` — passed
- `dart scripts/api_check.dart 1.3.0` — passed

This PR does not publish. After merge and green preflight, tag `v1.4.0` per `PUBLISHING.md`.
