### PR TITLE
feat: infer Object and Map<String, T> fields with Ack.map (#145)

### DIFF
--- a/docs/api-reference/index.mdx
+++ b/docs/api-reference/index.mdx
@@ -35,6 +35,9 @@ Entry point for creating schemas. See [Schema Types](../core-concepts/schemas.md
 - `Ack.anyOf(List<AckSchema> schemas)`: Creates an `AnyOfSchema` for union types.
 - `Ack.any()`: Creates an `AnySchema` that accepts any non-null JSON-safe
   value. Chain `.nullable()` to allow `null`.
+- `Ack.map(AckSchema valueSchema)`: Creates a `MapSchema` for a JSON object
+  with arbitrary string keys whose values all match `valueSchema`. Use
+  `Ack.map(Ack.any().nullable())` for a `JsonMap`.
 - `Ack.instance<T extends Object>()`: Creates a schema that checks a value is a
   Dart instance of `T` (runtime type check; handy as a codec `output` schema).
 - `Ack.codec(...)` / `Ack.date()` / `Ack.datetime()` / `Ack.uri()` /
@@ -199,7 +202,6 @@ Schema for validating objects (maps). See [Object Validation](../core-concepts/s
 Creates a detached, recursively unmodifiable snapshot of nested maps, lists,
 and sets. It does not validate JSON shape or values. Use it in hand-written
 constructors that store dynamic JSON maps and need stable equality and hashes.
-
 ## `SchemaResult<T>`
 
 Object returned by `safeParse()`. See [Error Handling](../core-concepts/error-handling.mdx).
@@ -306,11 +308,12 @@ Annotate a top-level schema variable or getter. The schema stays in your source 
 **Supported schema types:**
 - `Ack.object({...})` → immutable object models
 - Primitives: `Ack.string()`, `Ack.integer()`, `Ack.double()`, `Ack.boolean()`
-- Collections: `Ack.list(...)`, typed sets and maps
+- Collections: `Ack.list(...)`, `Ack.map(...)` fields, typed sets and maps
+- JSON values: `Ack.any()` fields as `Object` / `Object?`
 - Enums: `Ack.literal()`, `Ack.enumString()`, `Ack.enumValues()`
 - Discriminated unions: `Ack.discriminated(...)`
 
-**Unsupported:** nullable roots, one-way transforms, `Ack.any()`, `Ack.anyOf()`, bare `Ack.instance<T>()`, and anonymous inline objects
+**Unsupported:** nullable roots, one-way transforms, `Ack.any()` and `Ack.map()` roots, `Ack.anyOf()`, bare `Ack.instance<T>()`, and anonymous inline objects
 
 For `Ack.discriminated(...)` constraints with `@AckInfer`, see
 [Model Code Generation](../core-concepts/typesafe-schemas.mdx#schema-first-unions).
@@ -452,6 +455,22 @@ Accepts any non-null JSON-safe value without further validation.
 
 - Created by `Ack.any()`.
 - Useful for dynamic payloads or pass-through metadata.
+- Parsing returns a detached, recursively unmodifiable snapshot of the input;
+  encoding returns the runtime value unchanged after validating it.
+
+### `MapSchema<ValueBoundary, ValueRuntime>`
+
+Schema for a JSON object with arbitrary string keys whose values all match
+`valueSchema`.
+
+- Created by `Ack.map(valueSchema)`.
+- Boundary and runtime types are `Map<String, ValueBoundary?>` and
+  `Map<String, ValueRuntime?>`: a value may be `null` only when `valueSchema`
+  is nullable, so the static value type is always nullable.
+- Parse runs `valueSchema` on every value and encode on every non-null value,
+  including codecs; errors report the value's key path.
+- Exported to JSON Schema as
+  `{"type": "object", "additionalProperties": <value schema>}`.
 
 ### `CodecSchema<Boundary, Runtime>`
 

--- a/docs/api-reference/index.mdx
+++ b/docs/api-reference/index.mdx
@@ -314,7 +314,9 @@ Annotate a top-level schema variable or getter. The schema stays in your source 
 - Enums: `Ack.literal()`, `Ack.enumString()`, `Ack.enumValues()`
 - Discriminated unions: `Ack.discriminated(...)`
 
-**Unsupported:** nullable roots, one-way transforms, `Ack.any()` and `Ack.map()` roots, `Ack.anyOf()`, bare `Ack.instance<T>()`, and anonymous inline objects
+**Unsupported:** nullable roots, one-way transforms, `Ack.any()` and
+`Ack.map()` roots, `Ack.anyOf()`, bare `Ack.instance<T>()`, and anonymous
+inline objects
 
 For `Ack.discriminated(...)` constraints with `@AckInfer`, see
 [Model Code Generation](../core-concepts/typesafe-schemas.mdx#schema-first-unions).

--- a/docs/api-reference/index.mdx
+++ b/docs/api-reference/index.mdx
@@ -308,7 +308,8 @@ Annotate a top-level schema variable or getter. The schema stays in your source 
 **Supported schema types:**
 - `Ack.object({...})` → immutable object models
 - Primitives: `Ack.string()`, `Ack.integer()`, `Ack.double()`, `Ack.boolean()`
-- Collections: `Ack.list(...)`, `Ack.map(...)` fields, typed sets and maps
+- Collections: `Ack.list(...)`, `Ack.map(...)` fields, and codec-backed sets
+  and maps
 - JSON values: `Ack.any()` fields as `Object` / `Object?`
 - Enums: `Ack.literal()`, `Ack.enumString()`, `Ack.enumValues()`
 - Discriminated unions: `Ack.discriminated(...)`
@@ -465,8 +466,9 @@ Schema for a JSON object with arbitrary string keys whose values all match
 
 - Created by `Ack.map(valueSchema)`.
 - Boundary and runtime types are `Map<String, ValueBoundary?>` and
-  `Map<String, ValueRuntime?>`: a value may be `null` only when `valueSchema`
-  is nullable, so the static value type is always nullable.
+  `Map<String, ValueRuntime?>`. Nullability is a runtime flag in Ack, so the
+  static value type is nullable; a value is `null` only when `valueSchema` is
+  nullable.
 - Parse runs `valueSchema` on every value and encode on every non-null value,
   including codecs; errors report the value's key path.
 - Exported to JSON Schema as

--- a/docs/architecture/ackinfer-model-generation.md
+++ b/docs/architecture/ackinfer-model-generation.md
@@ -197,8 +197,8 @@ schema's encode output.
 
 `Ack.any()` fields and inferred class-first `Object` fields hold JSON-safe
 values. `Ack.any()` parsing returns a detached, recursively unmodifiable
-snapshot, so parsed `Object` values are frozen like collections without extra
-generated code; values passed directly to a constructor are stored as given.
+snapshot, so parsed `Object` values are frozen like collections; values passed
+directly to a constructor are stored as given.
 `Ack.map(...)` fields and inferred class-first `Map<String, T>` fields use the
 same string-keyed map contract; unlike list items, map values may be nullable.
 

--- a/docs/architecture/ackinfer-model-generation.md
+++ b/docs/architecture/ackinfer-model-generation.md
@@ -195,6 +195,13 @@ unknown data can't replace a declared property. Schema-first passthrough objects
 `toJson()` returns a fresh top-level collection; nested values are the
 schema's encode output.
 
+`Ack.any()` fields and inferred class-first `Object` fields hold JSON-safe
+values. `Ack.any()` parsing returns a detached, recursively unmodifiable
+snapshot, so parsed `Object` values are frozen like collections without extra
+generated code; values passed directly to a constructor are stored as given.
+`Ack.map(...)` fields and inferred class-first `Map<String, T>` fields use the
+same string-keyed map contract; unlike list items, map values may be nullable.
+
 Referenced schema variables are followed to their initializer so unsupported
 shapes are rejected regardless of whether they were written inline or assigned
 to a local.
@@ -205,7 +212,8 @@ Generation reports a located error for:
 
 - one-way `.transform()` calls;
 - nullable roots;
-- `Ack.any()`, `Ack.anyOf()`, and bare `Ack.instance<T>()`;
+- `Ack.any()` and `Ack.map()` roots (both are supported as fields),
+  `Ack.anyOf()`, and bare `Ack.instance<T>()`;
 - anonymous inline objects and unresolved dynamic schema factories;
 - runtime maps whose key type is not `String`;
 - invalid custom names and namespace/member collisions;

--- a/docs/core-concepts/schemas.mdx
+++ b/docs/core-concepts/schemas.mdx
@@ -224,6 +224,21 @@ final flexibleSchema = Ack.object({
 
 Use `Ack.any().nullable()` to also accept `null`.
 
+### Maps
+
+Use `Ack.map(...)` for a JSON object with arbitrary string keys whose values
+all share one schema:
+
+```dart
+final settingsSchema = Ack.object({
+  'scores': Ack.map(Ack.integer().min(0)), // string keys, int values
+  'metadata': Ack.map(Ack.any().nullable()), // a JsonMap
+});
+```
+
+Map values may be `null` only when the value schema is nullable. Use
+`Ack.object(...)` when the object has declared properties.
+
 ## Optional vs nullable
 
 **`.nullable()`** — Field must be present but can be `null`:

--- a/docs/core-concepts/typesafe-schemas.mdx
+++ b/docs/core-concepts/typesafe-schemas.mdx
@@ -270,7 +270,7 @@ values use the Dart types you already write:
 | Dart field | Inferred schema |
 | --- | --- |
 | `Object` | `Ack.any()` |
-| `Object?` | `Ack.any().nullable()`, with the same presence rules as `String?` |
+| `Object?` | `Ack.any().nullable()`; presence rules match `String?` |
 | `List<Object>` | `Ack.list(Ack.any())` |
 | `Map<String, T>` | `Ack.map(<schema for T>)` |
 | `Map<String, Object?>` | `Ack.map(Ack.any().nullable())` |

--- a/docs/core-concepts/typesafe-schemas.mdx
+++ b/docs/core-concepts/typesafe-schemas.mdx
@@ -321,10 +321,10 @@ final class Theme with _$ThemeAck {
 ```
 
 `@AckField` also replaces an inferred `Object` or `Map<String, V>` schema when
-the field needs a tighter contract, for example a `MapSchema<int, int>`
-function returning `Ack.map(Ack.integer().min(0))`. Non-String map keys and
-`dynamic` are rejected because they do not provide a static schema; use
-`Object?` for an open JSON value.
+the field needs a tighter contract, such as a function returning
+`Ack.map(Ack.integer().min(0))` for a `Map<String, int>` field. Non-String map
+keys and `dynamic` are rejected because they do not provide a static schema;
+use `Object?` for an open JSON value.
 Automatic `List<T>` and `Set<T>` inference also requires non-nullable element
 types because `Ack.list` has no nullable-item contract. An explicit
 `@AckField(schema: ...)` codec remains the escape hatch when a field deliberately

--- a/docs/core-concepts/typesafe-schemas.mdx
+++ b/docs/core-concepts/typesafe-schemas.mdx
@@ -129,10 +129,14 @@ models, aliases, defaults, additional properties, named lazy recursion, and
 same-library discriminated unions. Stored collections are copied recursively
 into unmodifiable collections.
 
+Fields may use `Ack.any()` for JSON-safe `Object` values and `Ack.map(...)` for
+string-keyed `Map<String, T>` values. `Ack.any().nullable()` infers `Object?`,
+and `Ack.map(Ack.any().nullable())` infers `Map<String, Object?>`.
+
 One-way transforms cannot back a generated model because there is no encoder.
-Generation also rejects nullable roots, `Ack.any()`, `Ack.anyOf()`, bare
-`Ack.instance<T>()`, anonymous inline object fields, unresolved dynamic schema
-factories, and cross-library union branches.
+Generation also rejects nullable roots, `Ack.any()` and `Ack.map()` roots,
+`Ack.anyOf()`, bare `Ack.instance<T>()`, anonymous inline object fields,
+unresolved dynamic schema factories, and cross-library union branches.
 
 ### Schema-first unions
 
@@ -260,7 +264,23 @@ final class Example with _$ExampleAck {
 and `{"label": null}` fails. Encoding omits a null Dart value.
 
 The generator infers `String`, `bool`, numeric types, `DateTime`, `Uri`,
-`Duration`, enums, nested lists, and sets. Sets use a list codec.
+`Duration`, enums, nested lists, and sets. Sets use a list codec. Open JSON
+values use the Dart types you already write:
+
+| Dart field | Inferred schema |
+| --- | --- |
+| `Object` | `Ack.any()` |
+| `Object?` | `Ack.any().nullable()`, with the same presence rules as `String?` |
+| `List<Object>` | `Ack.list(Ack.any())` |
+| `Map<String, T>` | `Ack.map(<schema for T>)` |
+| `Map<String, Object?>` | `Ack.map(Ack.any().nullable())` |
+
+`Object` means a JSON-safe value (a finite number, string, boolean, list, or
+string-keyed map of those values), not an arbitrary Dart instance, so a
+`DateTime` inside an `Object` or `Map<String, Object?>` field fails validation.
+Map values may be `null` only when the value type is nullable. `List<Object?>`
+stays rejected because `Ack.list` has no nullable-item contract. Parsed
+`Object` values are recursively unmodifiable, like other stored collections.
 
 Constraint annotations follow the field type:
 
@@ -300,9 +320,11 @@ final class Theme with _$ThemeAck {
 }
 ```
 
-`Map<String, V>` fields also use `@AckField`; class-first generation does not
-invent an `Ack.map()` runtime API. Non-String map keys, `dynamic`, and
-`Object?` fields are rejected because they do not provide a static schema.
+`@AckField` also replaces an inferred `Object` or `Map<String, V>` schema when
+the field needs a tighter contract, for example a `MapSchema<int, int>`
+function returning `Ack.map(Ack.integer().min(0))`. Non-String map keys and
+`dynamic` are rejected because they do not provide a static schema; use
+`Object?` for an open JSON value.
 Automatic `List<T>` and `Set<T>` inference also requires non-nullable element
 types because `Ack.list` has no nullable-item contract. An explicit
 `@AckField(schema: ...)` codec remains the escape hatch when a field deliberately

--- a/docs/guides/creating-schema-converter-packages.mdx
+++ b/docs/guides/creating-schema-converter-packages.mdx
@@ -1295,6 +1295,13 @@ static TargetSchema _convertDiscriminated(
 }
 ```
 
+### Handling Map Schema Models
+
+`Ack.map(valueSchema)` reaches converters as an `AckObjectSchemaModel` without
+`properties` whose `additionalProperties` is an `AckAdditionalPropertiesSchema`
+wrapping the value model. Targets without schema-valued additional properties
+can fall back to an open object, which drops value validation from the export.
+
 ### Handling Any Schema Models
 
 `Ack.any()` reaches converters as an `AckAnyOfSchemaModel` over the

--- a/docs/guides/json-schema-integration.mdx
+++ b/docs/guides/json-schema-integration.mdx
@@ -227,6 +227,9 @@ The nested nullable-union shape is intentional for generic Draft-7 output and ma
 -   **`additionalProperties`:** `Ack.object(..., additionalProperties: false)`
     becomes `additionalProperties: false`; `additionalProperties: true` is
     emitted as the boolean `true`.
+-   **`Ack.map(valueSchema)`:** Exported as
+    `{"type": "object", "additionalProperties": <value schema>}`. Map keys are
+    always strings, so no `propertyNames` keyword is emitted.
 -   **`Ack.any()`:** Runtime validation accepts non-null JSON-safe values.
     JSON-like adapter exports represent those JSON-compatible values and attach
     an `ack_any_json_boundary` warning to the `AckSchemaModel`.

--- a/llms.txt
+++ b/llms.txt
@@ -142,24 +142,39 @@ and `toJson()` instead of treating a model as its old boundary representation.
 - string, integer, double, number, boolean, list, literal, and enum roots;
 - built-in and custom bidirectional codecs;
 - lists, sets, and string-keyed `Map<String, T>` runtime values;
+- `Ack.any()` fields as JSON-safe `Object` values and `Ack.map(...)` fields as
+  `Map<String, T>` values;
 - named nested models, aliases, defaults, and additional properties;
 - direct, prefixed, and re-exported model and runtime type references;
 - named `Ack.lazy` self-recursion and mutual recursion;
 - same-library discriminated unions.
 
-Generation rejects nullable roots, one-way transforms, `Ack.any()`,
-`Ack.anyOf()`, bare `Ack.instance<T>()`, anonymous inline object fields,
-non-string map keys, unresolved dynamic factories, name collisions, and
-cross-library discriminated branches.
+Generation rejects nullable roots, one-way transforms, `Ack.any()` and
+`Ack.map()` roots, `Ack.anyOf()`, bare `Ack.instance<T>()`, anonymous inline
+object fields, non-string map keys, unresolved dynamic factories, name
+collisions, and cross-library discriminated branches.
 
 Class-first generation supports object models, inferred scalar and enum
-fields, nested lists, sets through list codecs, custom `@AckField` schemas,
-`@Optional()`, `@Required()`, `@NotNull()`, constructor defaults, case styles,
-`AckUnknownPropertyPolicy`, and same-library sealed discriminated unions. It
-rejects `dynamic`, `Object?`,
-non-String map keys, recursive class-first graphs, class-first value roots,
-undiscriminated `anyOf` models, missing `_$ClassAck` mixins, and no-op
-`@AckField()`.
+fields, JSON-safe `Object` fields, nested lists, sets through list codecs,
+string-keyed maps, custom `@AckField` schemas, `@Optional()`, `@Required()`,
+`@NotNull()`, constructor defaults, case styles, `AckUnknownPropertyPolicy`,
+and same-library sealed discriminated unions. It rejects `dynamic`, nullable
+list or set elements, non-String map keys, recursive class-first graphs,
+class-first value roots, undiscriminated `anyOf` models, missing `_$ClassAck`
+mixins, and no-op `@AckField()`.
+
+Open JSON fields are inferred from their Dart types. `Object` means a
+JSON-safe value (finite numbers, strings, booleans, lists, and string-keyed
+maps), not an arbitrary Dart instance:
+
+| Dart field | Inferred schema |
+| --- | --- |
+| `Object` | `Ack.any()` |
+| `Object?` | `Ack.any().nullable()`, with the same presence rules as `String?` |
+| `List<Object>` | `Ack.list(Ack.any())`; `List<Object?>` is rejected |
+| `Map<String, T>` | `Ack.map(<schema for T>)` |
+| `Map<String, Object?>` | `Ack.map(Ack.any().nullable())` |
+| `dynamic` | rejected; use `Object?` |
 
 ## Discriminated generated models
 

--- a/llms.txt
+++ b/llms.txt
@@ -170,7 +170,7 @@ maps), not an arbitrary Dart instance:
 | Dart field | Inferred schema |
 | --- | --- |
 | `Object` | `Ack.any()` |
-| `Object?` | `Ack.any().nullable()`, with the same presence rules as `String?` |
+| `Object?` | `Ack.any().nullable()`; presence rules match `String?` |
 | `List<Object>` | `Ack.list(Ack.any())`; `List<Object?>` is rejected |
 | `Map<String, T>` | `Ack.map(<schema for T>)` |
 | `Map<String, Object?>` | `Ack.map(Ack.any().nullable())` |

--- a/packages/ack/CHANGELOG.md
+++ b/packages/ack/CHANGELOG.md
@@ -1,3 +1,19 @@
+## Unreleased
+
+### Added
+
+* Add `Ack.map(valueSchema)` and `MapSchema` for JSON objects with arbitrary
+  string keys whose values all match one schema. Values may be `null` only
+  when the value schema is nullable, so `Ack.map(Ack.any().nullable())` models
+  a `JsonMap`. JSON Schema export emits `additionalProperties: <value schema>`.
+
+### Changed
+
+* `Ack.any()` parsing now returns a detached, recursively unmodifiable
+  snapshot of the input instead of the caller's own object, matching the
+  unmodifiable results of `Ack.object()` and `Ack.list()`. Encoding still
+  returns the validated runtime value unchanged.
+
 ## 1.4.0
 
 ### Changed

--- a/packages/ack/lib/src/ack.dart
+++ b/packages/ack/lib/src/ack.dart
@@ -50,6 +50,16 @@ final class Ack {
     AckSchema<B, R> itemSchema,
   ) => ListSchema<B, R>(itemSchema);
 
+  /// Creates a schema for a JSON object with arbitrary string keys whose
+  /// values all match [valueSchema].
+  ///
+  /// Use `Ack.map(Ack.any())` for a JSON object of non-null JSON-safe values
+  /// and `Ack.map(Ack.any().nullable())` for a `JsonMap` whose values may be
+  /// `null`. Use [object] when the object has declared properties.
+  static MapSchema<B, R> map<B extends Object, R extends Object>(
+    AckSchema<B, R> valueSchema,
+  ) => MapSchema<B, R>(valueSchema);
+
   /// Creates an enum schema for validating enum values.
   static EnumSchema<T> enumValues<T extends Enum>(List<T> values) {
     _requireNonEmpty(values, 'values');
@@ -91,7 +101,8 @@ final class Ack {
   ///
   /// Accepted values are finite numbers, strings, booleans, string-keyed maps,
   /// and lists recursively composed from those values. Mark the schema nullable
-  /// to accept `null`.
+  /// to accept `null`. Parsing returns a detached, recursively unmodifiable
+  /// snapshot of the input.
   static AnySchema any() => const AnySchema();
 
   /// Validates with [schema] while returning the original boundary value.

--- a/packages/ack/lib/src/schema_model/ack_schema_model_builder.dart
+++ b/packages/ack/lib/src/schema_model/ack_schema_model_builder.dart
@@ -118,6 +118,7 @@ final class _SchemaModelBuilder {
       BooleanSchema() => _boolean(schema),
       EnumSchema() => _enum(schema),
       ListSchema() => _array(schema),
+      MapSchema() => _map(schema),
       ObjectSchema() => _object(schema),
       AnyOfSchema() => _anyOf(schema),
       AnySchema() => _any(schema),
@@ -170,6 +171,16 @@ final class _SchemaModelBuilder {
       description: schema.description,
       nullable: schema.isNullable,
       items: _build(schema.itemSchema),
+    );
+  }
+
+  AckSchemaModel _map(MapSchema schema) {
+    return AckObjectSchemaModel(
+      description: schema.description,
+      nullable: schema.isNullable,
+      additionalProperties: AckAdditionalPropertiesSchema(
+        _build(schema.valueSchema),
+      ),
     );
   }
 

--- a/packages/ack/lib/src/schemas/any_schema.dart
+++ b/packages/ack/lib/src/schemas/any_schema.dart
@@ -1,6 +1,10 @@
 part of 'schema.dart';
 
 /// Schema that accepts any non-null JSON-safe value.
+///
+/// Parsing returns a detached, recursively unmodifiable snapshot of the input,
+/// so parsed JSON can't change through the caller's reference. Encoding
+/// validates the runtime value and returns it unchanged.
 @immutable
 final class AnySchema extends AckSchema<Object, Object>
     with FluentSchema<Object, Object, AnySchema> {
@@ -11,6 +15,18 @@ final class AnySchema extends AckSchema<Object, Object>
     super.constraints,
     super.refinements,
   });
+
+  @override
+  @protected
+  SchemaResult<Object> parseWithContext(Object? value, SchemaContext context) {
+    final result = validateRuntimeWithContext(value, context);
+    if (result.isFail) return result;
+    final validated = result.getOrNull();
+    if (validated == null) return result;
+
+    // Same deep, unmodifiable copy that schema defaults use.
+    return SchemaResult.ok(cloneDefault(validated)!);
+  }
 
   @override
   @protected

--- a/packages/ack/lib/src/schemas/map_schema.dart
+++ b/packages/ack/lib/src/schemas/map_schema.dart
@@ -1,0 +1,204 @@
+part of 'schema.dart';
+
+/// Schema for JSON objects with arbitrary string keys whose values all
+/// conform to [valueSchema].
+///
+/// `MapSchema` models open records such as `Map<String, int>` or a `JsonMap`.
+/// Use `Ack.object(...)` for objects with declared properties.
+///
+/// ## Null values
+///
+/// A value may be `null` only when [valueSchema] accepts null, so
+/// `Ack.map(Ack.any().nullable())` models `Map<String, Object?>`. Because
+/// nullability is a runtime flag in Ack, the static value types are nullable
+/// even when [valueSchema] rejects null.
+///
+/// The `optional` flag of [valueSchema] has no effect: a map has no declared
+/// keys that could be missing.
+@immutable
+final class MapSchema<ValueBoundary extends Object, ValueRuntime extends Object>
+    extends AckSchema<Map<String, ValueBoundary?>, Map<String, ValueRuntime?>>
+    with
+        FluentSchema<
+          Map<String, ValueBoundary?>,
+          Map<String, ValueRuntime?>,
+          MapSchema<ValueBoundary, ValueRuntime>
+        > {
+  final AckSchema<ValueBoundary, ValueRuntime> valueSchema;
+
+  const MapSchema(
+    this.valueSchema, {
+    super.isNullable,
+    super.isOptional,
+    super.description,
+    super.constraints,
+    super.refinements,
+  });
+
+  SchemaResult<Map<String, ValueRuntime?>> _processEntries(
+    Object? value,
+    SchemaContext context, {
+    required bool parse,
+  }) {
+    final nullResult = handleNullInput(value, context);
+    if (nullResult != null) return nullResult;
+
+    final mapValue = jsonMapOrNull(value);
+    if (mapValue == null) {
+      return SchemaResult.fail(
+        _buildTypeMismatch(
+          expectedType: schemaType,
+          actualValue: value,
+          context: context,
+        ),
+      );
+    }
+
+    final isEncode = context.operation == SchemaOperation.encode;
+    final typed = <String, ValueRuntime?>{};
+    final errors = <SchemaError>[];
+    for (final MapEntry(:key, value: item) in mapValue.entries) {
+      final itemCtx = context.createChild(
+        name: key,
+        schema: valueSchema,
+        value: item,
+        pathSegment: key,
+      );
+      if (item == null && isEncode) {
+        if (valueSchema.acceptsNull) {
+          typed[key] = null;
+        } else {
+          errors.add(SchemaEncodeError.nonNullable(context: itemCtx));
+        }
+        continue;
+      }
+      final r = parse
+          ? valueSchema.parseWithContext(item, itemCtx)
+          : valueSchema.validateRuntimeWithContext(item, itemCtx);
+      r.match(
+        onOk: (v) {
+          typed[key] = v;
+        },
+        onFail: errors.add,
+      );
+    }
+
+    if (errors.isNotEmpty) {
+      return SchemaResult.fail(
+        SchemaNestedError(errors: errors, context: context),
+      );
+    }
+
+    return applyConstraintsAndRefinements(
+      Map<String, ValueRuntime?>.unmodifiable(typed),
+      context,
+    );
+  }
+
+  @override
+  @protected
+  SchemaResult<Map<String, ValueRuntime?>> parseWithContext(
+    Object? value,
+    SchemaContext context,
+  ) => _processEntries(value, context, parse: true);
+
+  @override
+  @protected
+  SchemaResult<Map<String, ValueRuntime?>> validateRuntimeWithContext(
+    Object? value,
+    SchemaContext context,
+  ) => _processEntries(value, context, parse: false);
+
+  @override
+  @protected
+  SchemaResult<Map<String, ValueBoundary?>> encodeWithContext(
+    Map<String, ValueRuntime?> value,
+    SchemaContext context,
+  ) {
+    final validated = validateRuntimeWithContext(value, context);
+    if (validated.isFail) return SchemaResult.fail(validated.getError());
+
+    final encoded = <String, ValueBoundary?>{};
+    final errors = <SchemaError>[];
+    for (final MapEntry(:key, value: item) in value.entries) {
+      if (item == null) {
+        encoded[key] = null;
+        continue;
+      }
+      final itemCtx = context.createChild(
+        name: key,
+        schema: valueSchema,
+        value: item,
+        pathSegment: key,
+        operation: SchemaOperation.encode,
+      );
+      try {
+        final r = valueSchema.encodeWithContext(item, itemCtx);
+        if (r.isFail) {
+          errors.add(r.getError());
+        } else {
+          encoded[key] = r.getOrNull();
+        }
+      } catch (e, st) {
+        errors.add(
+          SchemaEncodeError.encoderThrew(
+            message: 'Map value "$key" encoder threw: $e',
+            context: itemCtx,
+            cause: e,
+            stackTrace: st,
+          ),
+        );
+      }
+    }
+    if (errors.isNotEmpty) {
+      return SchemaResult.fail(
+        SchemaNestedError(errors: errors, context: context),
+      );
+    }
+
+    return SchemaResult.ok(Map<String, ValueBoundary?>.unmodifiable(encoded));
+  }
+
+  @override
+  MapSchema<ValueBoundary, ValueRuntime> copyWith({
+    bool? isNullable,
+    bool? isOptional,
+    String? description,
+    List<Constraint<Map<String, ValueRuntime?>>>? constraints,
+    List<Refinement<Map<String, ValueRuntime?>>>? refinements,
+  }) {
+    return MapSchema(
+      valueSchema,
+      isNullable: isNullable ?? this.isNullable,
+      isOptional: isOptional ?? this.isOptional,
+      description: description ?? this.description,
+      constraints: constraints ?? this.constraints,
+      refinements: refinements ?? this.refinements,
+    );
+  }
+
+  @override
+  Map<String, Object?> toMap() {
+    return {
+      'type': schemaType.typeName,
+      'isNullable': isNullable,
+      'description': description,
+      'constraints': constraints.map((c) => c.toMap()).toList(),
+      'valueSchema': valueSchema.schemaType.typeName,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! MapSchema<ValueBoundary, ValueRuntime>) return false;
+
+    return baseFieldsEqual(other) && valueSchema == other.valueSchema;
+  }
+
+  @override
+  SchemaType get schemaType => SchemaType.object;
+
+  @override
+  int get hashCode => Object.hash(baseFieldsHashCode, valueSchema);
+}

--- a/packages/ack/lib/src/schemas/schema.dart
+++ b/packages/ack/lib/src/schemas/schema.dart
@@ -24,6 +24,7 @@ part 'fluent_schema.dart';
 part 'instance_schema.dart';
 part 'lazy_schema.dart';
 part 'list_schema.dart';
+part 'map_schema.dart';
 part 'num_schema.dart';
 part 'object_schema.dart';
 part 'schema_type.dart';

--- a/packages/ack/test/documentation/core_concepts_schemas_examples_test.dart
+++ b/packages/ack/test/documentation/core_concepts_schemas_examples_test.dart
@@ -196,6 +196,28 @@ void main() {
       expect(result.isOk, isTrue);
     });
 
+    test('map schema validates every value under arbitrary keys', () {
+      final settingsSchema = Ack.object({
+        'scores': Ack.map(Ack.integer().min(0)),
+        'metadata': Ack.map(Ack.any().nullable()),
+      });
+
+      expect(
+        settingsSchema.safeParse({
+          'scores': {'alice': 3, 'bob': 0},
+          'metadata': {'trace': null, 'tags': <Object?>[]},
+        }).isOk,
+        isTrue,
+      );
+      expect(
+        settingsSchema.safeParse({
+          'scores': {'alice': -1},
+          'metadata': <String, Object?>{},
+        }).isFail,
+        isTrue,
+      );
+    });
+
     group('Optional vs nullable semantics', () {
       test('nullable requires presence but allows null', () {
         final schema = Ack.object({

--- a/packages/ack/test/schema_model/ack_schema_model_builder_test.dart
+++ b/packages/ack/test/schema_model/ack_schema_model_builder_test.dart
@@ -108,6 +108,8 @@ void main() {
         }, additionalProperties: true),
       );
       expectDirectMatchesModel(Ack.any());
+      expectDirectMatchesModel(Ack.map(Ack.integer().min(0)).nullable());
+      expectDirectMatchesModel(Ack.map(Ack.any().nullable()));
       expectDirectMatchesModel(
         Ack.anyOf([Ack.string(), Ack.integer()]).nullable(),
       );

--- a/packages/ack/test/schemas/any_schema_test.dart
+++ b/packages/ack/test/schemas/any_schema_test.dart
@@ -44,6 +44,36 @@ void main() {
       expect(schema.safeEncode(value).getOrThrow(), equals(value));
     });
 
+    test('parse returns a detached, unmodifiable JSON snapshot', () {
+      final nested = <String, Object?>{
+        'items': [1],
+      };
+      final source = <dynamic, dynamic>{'nested': nested};
+
+      final parsed = Ack.any().parse(source)! as Map<String, Object?>;
+      nested['later'] = true;
+
+      expect(parsed, {
+        'nested': {
+          'items': [1],
+        },
+      });
+      expect(() => parsed['x'] = 1, throwsUnsupportedError);
+      final parsedNested = parsed['nested']! as Map<String, Object?>;
+      expect(() => parsedNested['x'] = 1, throwsUnsupportedError);
+      expect(
+        () => (parsedNested['items']! as List<Object?>).add(2),
+        throwsUnsupportedError,
+      );
+      expect(Ack.any().parse('text'), 'text');
+    });
+
+    test('encode and runtime validation keep the runtime value', () {
+      final value = <String, Object?>{'a': 1};
+
+      expect(Ack.any().encode(value), same(value));
+    });
+
     test('should reject null by default', () {
       final schema = Ack.any();
       final result = schema.safeParse(null);

--- a/packages/ack/test/schemas/any_schema_test.dart
+++ b/packages/ack/test/schemas/any_schema_test.dart
@@ -68,7 +68,7 @@ void main() {
       expect(Ack.any().parse('text'), 'text');
     });
 
-    test('encode and runtime validation keep the runtime value', () {
+    test('encode returns the validated runtime value unchanged', () {
       final value = <String, Object?>{'a': 1};
 
       expect(Ack.any().encode(value), same(value));

--- a/packages/ack/test/schemas/map_schema_test.dart
+++ b/packages/ack/test/schemas/map_schema_test.dart
@@ -1,11 +1,11 @@
 import 'package:ack/ack.dart';
 import 'package:test/test.dart';
 
-SchemaError _singleNestedError(SchemaResult<Object> result) {
-  final error = result.getError();
-  expect(error, isA<SchemaNestedError>());
-  return (error as SchemaNestedError).errors.single;
-}
+Matcher _nestedErrorAt(String path) => isA<SchemaNestedError>().having(
+  (error) => error.errors.single.context.path,
+  'single nested error path',
+  path,
+);
 
 void main() {
   group('MapSchema', () {
@@ -20,9 +20,10 @@ void main() {
     test('reports invalid values at their key path', () {
       final schema = Ack.map(Ack.integer());
 
-      final error = _singleNestedError(schema.safeParse({'a': 1, 'b': 'two'}));
-
-      expect(error.context.path, '#/b');
+      expect(
+        schema.safeParse({'a': 1, 'b': 'two'}).getError(),
+        _nestedErrorAt('#/b'),
+      );
     });
 
     test('rejects null, non-map input, and non-string keys', () {
@@ -35,11 +36,10 @@ void main() {
     });
 
     test('rejects null values unless the value schema is nullable', () {
-      final error = _singleNestedError(
-        Ack.map(Ack.any()).safeParse({'a': null}),
+      expect(
+        Ack.map(Ack.any()).safeParse({'a': null}).getError(),
+        _nestedErrorAt('#/a'),
       );
-
-      expect(error.context.path, '#/a');
       expect(Ack.map(Ack.any().nullable()).parse({'a': null}), {'a': null});
     });
 
@@ -77,12 +77,18 @@ void main() {
     test('encodes null values only when the value schema accepts null', () {
       expect(Ack.map(Ack.string().nullable()).encode({'a': null}), {'a': null});
 
-      final result = Ack.map(Ack.string()).safeEncode({'a': null});
-
-      expect(result.getError(), isA<SchemaNestedError>());
-      final error = (result.getError() as SchemaNestedError).errors.single;
-      expect(error, isA<SchemaEncodeError>());
-      expect(error.context.path, '#/a');
+      expect(
+        Ack.map(Ack.string()).safeEncode({'a': null}).getError(),
+        isA<SchemaNestedError>().having(
+          (error) => error.errors.single,
+          'single nested error',
+          isA<SchemaEncodeError>().having(
+            (error) => error.context.path,
+            'path',
+            '#/a',
+          ),
+        ),
+      );
     });
 
     test('returns unmodifiable parsed and encoded maps', () {
@@ -114,15 +120,15 @@ void main() {
         'meta': null,
       });
 
-      final scoresError = _singleNestedError(
+      expect(
         schema.safeParse({
           'scores': {'a': 'x'},
-        }),
-      );
-      expect(scoresError, isA<SchemaNestedError>());
-      expect(
-        (scoresError as SchemaNestedError).errors.single.context.path,
-        '#/scores/a',
+        }).getError(),
+        isA<SchemaNestedError>().having(
+          (error) => error.errors.single,
+          'scores error',
+          _nestedErrorAt('#/scores/a'),
+        ),
       );
     });
 

--- a/packages/ack/test/schemas/map_schema_test.dart
+++ b/packages/ack/test/schemas/map_schema_test.dart
@@ -1,0 +1,167 @@
+import 'package:ack/ack.dart';
+import 'package:test/test.dart';
+
+SchemaError _singleNestedError(SchemaResult<Object> result) {
+  final error = result.getError();
+  expect(error, isA<SchemaNestedError>());
+  return (error as SchemaNestedError).errors.single;
+}
+
+void main() {
+  group('MapSchema', () {
+    test('parses string-keyed maps whose values match the value schema', () {
+      final schema = Ack.map(Ack.integer());
+
+      expect(schema.parse({'a': 1, 'b': 2}), {'a': 1, 'b': 2});
+      expect(schema.parse(<String, Object?>{}), isEmpty);
+      expect(schema.parse(<dynamic, dynamic>{'a': 1}), {'a': 1});
+    });
+
+    test('reports invalid values at their key path', () {
+      final schema = Ack.map(Ack.integer());
+
+      final error = _singleNestedError(schema.safeParse({'a': 1, 'b': 'two'}));
+
+      expect(error.context.path, '#/b');
+    });
+
+    test('rejects null, non-map input, and non-string keys', () {
+      final schema = Ack.map(Ack.string());
+
+      expect(schema.safeParse(null).isFail, isTrue);
+      expect(schema.safeParse(['a']).isFail, isTrue);
+      expect(schema.safeParse({1: 'one'}).isFail, isTrue);
+      expect(schema.nullable().safeParse(null).getOrThrow(), isNull);
+    });
+
+    test('rejects null values unless the value schema is nullable', () {
+      final error = _singleNestedError(
+        Ack.map(Ack.any()).safeParse({'a': null}),
+      );
+
+      expect(error.context.path, '#/a');
+      expect(Ack.map(Ack.any().nullable()).parse({'a': null}), {'a': null});
+    });
+
+    test('Ack.any values accept JSON trees and reject non-JSON values', () {
+      final schema = Ack.map(Ack.any().nullable());
+      final value = {
+        'nested': [
+          null,
+          1,
+          {'ok': true},
+        ],
+      };
+
+      expect(schema.parse(value), value);
+      expect(schema.encode(value), value);
+      expect(schema.safeParse({'at': DateTime(2026)}).isFail, isTrue);
+      expect(
+        schema.safeParse({
+          'nested': {'at': DateTime(2026)},
+        }).isFail,
+        isTrue,
+      );
+      expect(schema.safeEncode({'at': DateTime(2026)}).isFail, isTrue);
+    });
+
+    test('decodes and encodes value codecs', () {
+      final schema = Ack.map(Ack.date());
+
+      final parsed = schema.parse({'start': '2026-01-02'})!;
+
+      expect(parsed['start'], DateTime(2026, 1, 2));
+      expect(schema.encode(parsed), {'start': '2026-01-02'});
+    });
+
+    test('encodes null values only when the value schema accepts null', () {
+      expect(Ack.map(Ack.string().nullable()).encode({'a': null}), {'a': null});
+
+      final result = Ack.map(Ack.string()).safeEncode({'a': null});
+
+      expect(result.getError(), isA<SchemaNestedError>());
+      final error = (result.getError() as SchemaNestedError).errors.single;
+      expect(error, isA<SchemaEncodeError>());
+      expect(error.context.path, '#/a');
+    });
+
+    test('returns unmodifiable parsed and encoded maps', () {
+      final schema = Ack.map(Ack.string());
+
+      final parsed = schema.parse({'a': 'x'})!;
+      final encoded = schema.encode({'a': 'x'})!;
+
+      expect(() => parsed['b'] = 'y', throwsUnsupportedError);
+      expect(() => encoded['b'] = 'y', throwsUnsupportedError);
+    });
+
+    test('composes as an optional or nullable object property', () {
+      final schema = Ack.object({
+        'scores': Ack.map(Ack.integer()),
+        'meta': Ack.map(Ack.any().nullable()).optional().nullable(),
+      });
+
+      expect(
+        schema.parse({
+          'scores': {'a': 1},
+        }),
+        {
+          'scores': {'a': 1},
+        },
+      );
+      expect(schema.parse({'scores': <String, Object?>{}, 'meta': null}), {
+        'scores': <String, Object?>{},
+        'meta': null,
+      });
+
+      final scoresError = _singleNestedError(
+        schema.safeParse({
+          'scores': {'a': 'x'},
+        }),
+      );
+      expect(scoresError, isA<SchemaNestedError>());
+      expect(
+        (scoresError as SchemaNestedError).errors.single.context.path,
+        '#/scores/a',
+      );
+    });
+
+    test('applies refinements to the whole map', () {
+      final schema = Ack.map(
+        Ack.string(),
+      ).refine((map) => map.length <= 1, message: 'At most one entry.');
+
+      expect(schema.safeParse({'a': 'x'}).isOk, isTrue);
+      expect(schema.safeParse({'a': 'x', 'b': 'y'}).isFail, isTrue);
+    });
+
+    test('supports equality and copyWith', () {
+      expect(Ack.map(Ack.string()), Ack.map(Ack.string()));
+      expect(Ack.map(Ack.string()).hashCode, Ack.map(Ack.string()).hashCode);
+      expect(Ack.map(Ack.string()), isNot(Ack.map(Ack.string().nullable())));
+      expect(Ack.map(Ack.string()), isNot(Ack.map(Ack.string()).nullable()));
+
+      final copied = Ack.map(
+        Ack.string(),
+      ).describe('Labels').copyWith(description: 'Tags');
+
+      expect(copied.description, 'Tags');
+      expect(copied.valueSchema, Ack.string());
+    });
+
+    test('exports additionalProperties with the value schema', () {
+      expect(Ack.map(Ack.string()).toJsonSchema(), {
+        'type': 'object',
+        'additionalProperties': {'type': 'string'},
+      });
+      expect(
+        Ack.map(Ack.integer()).describe('Scores').toSchemaModel(),
+        isA<AckObjectSchemaModel>().having(
+          (model) => model.additionalProperties,
+          'additionalProperties',
+          isA<AckAdditionalPropertiesSchema>(),
+        ),
+      );
+    });
+  });
+}

--- a/packages/ack_generator/CHANGELOG.md
+++ b/packages/ack_generator/CHANGELOG.md
@@ -1,3 +1,24 @@
+## Unreleased
+
+### Added
+
+* Infer open JSON class-first fields from their Dart types: `Object` →
+  `Ack.any()`, `Object?` → `Ack.any().nullable()` (with the same presence
+  annotations as `String?`), `List<Object>` → `Ack.list(Ack.any())`, and
+  `Map<String, T>` → `Ack.map(<schema for T>)`, including
+  `Map<String, Object?>`. `Map` fields no longer require `@AckField`, which
+  still overrides an inferred schema. `dynamic`, `List<Object?>`, and
+  non-`String` map keys stay rejected; the `dynamic` error now suggests
+  `Object?`.
+* Accept `Ack.any()` and `Ack.map(...)` schema-first fields, inferring
+  `Object`/`Object?` and `Map<String, T>`. `Ack.any()` and `Ack.map()` model
+  roots stay rejected, including when reached through a variable.
+
+### Fixed
+
+* Omit the redundant `as Object?` cast in generated `copyWith` bodies for
+  `Object?` fields.
+
 ## 1.4.0
 
 ### Added

--- a/packages/ack_generator/CHANGELOG.md
+++ b/packages/ack_generator/CHANGELOG.md
@@ -18,6 +18,13 @@
 
 * Omit the redundant `as Object?` cast in generated `copyWith` bodies for
   `Object?` fields.
+* Infer nullable `Ack.map` values when the value schema is a variable declared
+  with `.nullable()`, such as `Ack.map(nullableLabel)`.
+* Keep generated code clean under `--fatal-infos`: fieldless class-first
+  models no longer declare an unused `self` local, and nullable collection
+  bridges use null-aware access.
+* Generate compiling code for nullable class-first `Set<T>?` fields; the set
+  codec now uses the non-null set type and presence adds nullability.
 
 ## 1.4.0
 

--- a/packages/ack_generator/README.md
+++ b/packages/ack_generator/README.md
@@ -152,6 +152,17 @@ requiring the key, and `@AckField(schema: ...)` for custom codecs. See the
 for both directions, field inference, sealed unions, passthrough properties,
 and build configuration.
 
+Open JSON fields are inferred from their Dart types. `Object` means a JSON-safe
+value, not an arbitrary Dart instance:
+
+| Dart field | Inferred schema |
+| --- | --- |
+| `Object` / `Object?` | `Ack.any()` / `Ack.any().nullable()` |
+| `List<Object>` | `Ack.list(Ack.any())`; `List<Object?>` is rejected |
+| `Map<String, T>` | `Ack.map(<schema for T>)` |
+| `Map<String, Object?>` | `Ack.map(Ack.any().nullable())` |
+| `dynamic` | rejected; use `Object?` |
+
 For a hand-written `Account`, class-first generation exposes an
 `AccountSchema` facade backed by a private `_accountSchema` codec. The facade
 provides parsing, safe parsing, encoding, JSON Schema/schema-model export,

--- a/packages/ack_generator/README.md
+++ b/packages/ack_generator/README.md
@@ -102,7 +102,8 @@ Generation rejects shapes without a useful static, encodable model contract:
 - nullable `Ack.list` item schemas and automatically inferred `List<T?>` or
   `Set<T?>` fields; make the collection nullable instead, or use an explicit
   `@AckField(schema: ...)` codec for a different collection contract;
-- `Ack.any()`, `Ack.anyOf()`, and bare `Ack.instance<T>()`;
+- `Ack.any()` and `Ack.map()` roots (both are supported as fields),
+  `Ack.anyOf()`, and bare `Ack.instance<T>()`;
 - anonymous inline object fields and unresolved dynamic schema factories;
 - invalid names, generated-member collisions, and cross-library union branches.
 

--- a/packages/ack_generator/lib/src/analyzer/class_model_graph_builder.dart
+++ b/packages/ack_generator/lib/src/analyzer/class_model_graph_builder.dart
@@ -809,7 +809,12 @@ final class ClassModelGraphBuilder {
   }
 
   String _setCodec(String listSchema, AckInferRef runtimeRef) {
-    final rendered = _renderType(_schemaRuntimeRef(runtimeRef));
+    // Presence adds nullability to the codec; its type argument is the set.
+    final setType = switch (runtimeRef) {
+      AckNullableTypeRef(:final inner) => inner,
+      _ => runtimeRef,
+    };
+    final rendered = _renderType(_schemaRuntimeRef(setType));
     return '$listSchema.codec<$rendered>('
         'decode: (list) => list.toSet(), '
         'encode: (set) => set.toList(growable: false),'

--- a/packages/ack_generator/lib/src/analyzer/class_model_graph_builder.dart
+++ b/packages/ack_generator/lib/src/analyzer/class_model_graph_builder.dart
@@ -1210,6 +1210,8 @@ final class ClassModelGraphBuilder {
     if (_isCore(interfaceType, 'DateTime')) return '${_ack('Ack')}.datetime()';
     if (_isCore(interfaceType, 'Uri')) return '${_ack('Ack')}.uri()';
     if (_isCore(interfaceType, 'Duration')) return '${_ack('Ack')}.duration()';
+    // Object means a JSON-safe value, not an arbitrary Dart instance.
+    if (_isCore(interfaceType, 'Object')) return '${_ack('Ack')}.any()';
     if (interfaceType.element is EnumElement) {
       return '${_ack('Ack')}.enumValues(${_visibleTypeName(interfaceType)}.values)';
     }
@@ -1232,11 +1234,12 @@ final class ClassModelGraphBuilder {
           ')';
     }
     if (interfaceType.isDartCoreMap) {
-      throw InvalidGenerationSource(
-        '${field.enclosingElement.name}.${field.name} uses Map<String, V>; '
-        'Map fields require @AckField(schema: ...).',
-        element: field,
-      );
+      _validateMapKey(field, interfaceType);
+      // Unlike list items, JSON object values may be null.
+      final valueType = interfaceType.typeArguments[1];
+      final value = await _schemaForType(valueType, field);
+      final nullable = _isNullable(valueType) ? '.nullable()' : '';
+      return '${_ack('Ack')}.map($value$nullable)';
     }
     final target = interfaceType.element;
     if (target is ClassElement) {
@@ -1404,18 +1407,19 @@ final class ClassModelGraphBuilder {
   }
 
   void _rejectUnsupportedStaticType(FieldElement field, DartType type) {
-    if (type is DynamicType ||
-        type is TypeParameterType ||
-        (type is InterfaceType && _isCore(type, 'Object'))) {
+    if (type is DynamicType || type is TypeParameterType) {
       _unsupportedFieldType(field, type);
     }
   }
 
   Never _unsupportedFieldType(FieldElement field, DartType type) {
+    final jsonHint = type is DynamicType
+        ? ', or Object? for an open JSON value'
+        : '';
     throw InvalidGenerationSource(
       '${field.enclosingElement.name}.${field.name} uses unsupported '
       '${type.getDisplayString()}; use a concrete type with a static '
-      'class-first schema contract.',
+      'class-first schema contract$jsonHint.',
       element: field,
     );
   }

--- a/packages/ack_generator/lib/src/analyzer/schema_model_graph_builder.dart
+++ b/packages/ack_generator/lib/src/analyzer/schema_model_graph_builder.dart
@@ -722,8 +722,9 @@ final class SchemaModelGraphBuilder {
           depth: depth,
         );
         // Unlike list items, JSON object values may be null.
+        final nullableValue = await _isNullableSchema(arguments.first);
         return AckMapTypeRef(
-          _chain(arguments.first).nullable && valueType is! AckNullableTypeRef
+          nullableValue && valueType is! AckNullableTypeRef
               ? AckNullableTypeRef(valueType)
               : valueType,
         );
@@ -864,6 +865,33 @@ final class SchemaModelGraphBuilder {
       followedName: element.name,
       collectionElement: collectionElement,
     );
+  }
+
+  /// Whether [expression] marks its schema `.nullable()`, following
+  /// unannotated variable references such as `Ack.map(nullableLabel)`.
+  Future<bool> _isNullableSchema(Expression expression, {int depth = 0}) async {
+    final chain = _chain(expression);
+    if (chain.nullable) return true;
+    final reference = chain.reference;
+    if (chain.base != null ||
+        reference == null ||
+        depth >= _maxReferenceDepth) {
+      return false;
+    }
+    final element = _referencedElement(reference);
+    if (element == null ||
+        (element is! TopLevelVariableElement && element is! GetterElement)) {
+      return false;
+    }
+    final declaration = _propertyDeclaration(element);
+    final owningLibrary = declaration.library;
+    if (owningLibrary == null) return false;
+    final initializer = _declarationExpression(
+      await _resolvedLibraryFor(owningLibrary),
+      declaration,
+    );
+    return initializer != null &&
+        await _isNullableSchema(initializer, depth: depth + 1);
   }
 
   Future<AckInferRef> _lazyType(

--- a/packages/ack_generator/lib/src/analyzer/schema_model_graph_builder.dart
+++ b/packages/ack_generator/lib/src/analyzer/schema_model_graph_builder.dart
@@ -1,5 +1,5 @@
 import 'package:ack/ack.dart'
-    show AckSchema, AnyOfSchema, AnySchema, InstanceSchema;
+    show AckSchema, AnyOfSchema, AnySchema, InstanceSchema, MapSchema;
 import 'package:ack_annotations/ack_annotations.dart'
     hide AckUnknownPropertyPolicy;
 import 'package:analyzer/dart/analysis/results.dart';
@@ -174,6 +174,10 @@ final class SchemaModelGraphBuilder {
   );
   static const _instanceSchemaChecker = TypeChecker.typeNamed(
     InstanceSchema,
+    inPackage: 'ack',
+  );
+  static const _mapSchemaChecker = TypeChecker.typeNamed(
+    MapSchema,
     inPackage: 'ack',
   );
 
@@ -358,6 +362,22 @@ final class SchemaModelGraphBuilder {
         'codec',
         'lazy',
       };
+      // Ack.any() and Ack.map() are valid fields but never model roots,
+      // whether written inline or reached through an unannotated variable.
+      final rootType = declaration.expression.staticType;
+      if (rootType != null &&
+          _anySchemaChecker.isAssignableFromType(rootType)) {
+        _rejectUnsupportedRoot('any', path, declaration.element);
+      }
+      if (rootType != null &&
+          _mapSchemaChecker.isAssignableFromType(rootType)) {
+        throw InvalidGenerationSource(
+          '$path uses an Ack.map() root. Generated models need an object or '
+          'value root.',
+          element: declaration.element,
+          todo: 'Use Ack.map(...) as a field of an Ack.object(...) model.',
+        );
+      }
       if (baseName != null && !supportedValueRoots.contains(baseName)) {
         _rejectUnsupportedRoot(baseName, path, declaration.element);
       }
@@ -680,9 +700,33 @@ final class SchemaModelGraphBuilder {
           element: context,
         );
       case 'any':
+        // A JSON-safe value field. Ack.any() roots are rejected in _resolve.
+        return const AckScalarTypeRef('Object');
       case 'anyOf':
       case 'instance':
         _rejectUnsupportedRoot(baseName, path, context);
+      case 'map':
+        final arguments = _argumentExpressions(chain.base!.argumentList);
+        if (arguments.isEmpty) {
+          throw InvalidGenerationSource(
+            '$path has an empty Ack.map().',
+            element: context,
+          );
+        }
+        final valueType = await _runtimeRefForSchema(
+          arguments.first,
+          path: '$path{}',
+          context: context,
+          throughLazy: throughLazy,
+          visited: visited,
+          depth: depth,
+        );
+        // Unlike list items, JSON object values may be null.
+        return AckMapTypeRef(
+          _chain(arguments.first).nullable && valueType is! AckNullableTypeRef
+              ? AckNullableTypeRef(valueType)
+              : valueType,
+        );
       case 'list':
         final arguments = _argumentExpressions(chain.base!.argumentList);
         if (arguments.isEmpty) {
@@ -1577,9 +1621,6 @@ final class SchemaModelGraphBuilder {
   ) {
     final type = expression.staticType;
     if (type == null) return;
-    if (_anySchemaChecker.isAssignableFromType(type)) {
-      _rejectUnsupportedRoot('any', path, element);
-    }
     if (_anyOfSchemaChecker.isAssignableFromType(type)) {
       _rejectUnsupportedRoot('anyOf', path, element);
     }

--- a/packages/ack_generator/lib/src/builders/class_model_emitter.dart
+++ b/packages/ack_generator/lib/src/builders/class_model_emitter.dart
@@ -374,6 +374,12 @@ Map<String, Object?> $function(${node.className} model) {
     AckNullableTypeRef(:final inner)
         when inner is AckScalarTypeRef || inner is AckExternalTypeRef =>
       expression,
+    // `value?.map(...)` satisfies prefer_null_aware_operators.
+    AckNullableTypeRef(:final inner)
+        when inner is AckListTypeRef ||
+            inner is AckSetTypeRef ||
+            inner is AckMapTypeRef =>
+      _toRuntime(inner, '$expression?'),
     AckNullableTypeRef(:final inner) =>
       '$expression == null ? null : ${_toRuntime(inner, expression)}',
     AckModelTypeRef(:final visibleName) =>

--- a/packages/ack_generator/lib/src/builders/class_model_emitter.dart
+++ b/packages/ack_generator/lib/src/builders/class_model_emitter.dart
@@ -343,6 +343,9 @@ Map<String, Object?> $function(${node.className} model) {
   }
 
   String _fromRuntime(AckInferRef type, String expression) => switch (type) {
+    // Any input is already assignable to Object?; a cast would be redundant.
+    AckNullableTypeRef(inner: AckScalarTypeRef(dartType: 'Object')) =>
+      expression,
     AckNullableTypeRef(:final inner)
         when inner is AckScalarTypeRef || inner is AckExternalTypeRef =>
       '$expression as ${_type(type)}',

--- a/packages/ack_generator/lib/src/builders/data_class_emitter.dart
+++ b/packages/ack_generator/lib/src/builders/data_class_emitter.dart
@@ -172,10 +172,15 @@ ${_ack('SchemaResult')}<Map<String, Object?>> safeToJson() =>
       '${_type(parameter.typeRef)}?';
 
   String _copyWithArgument(AckConstructorParameter parameter, String receiver) {
+    final type = _type(parameter.typeRef);
+    // Sentinel parameters are already typed Object?.
+    final value = type == 'Object?'
+        ? parameter.name
+        : '${parameter.name} as $type';
     final replacement = _usesCopyWithSentinel(parameter)
         ? 'identical(${parameter.name}, $_copyWithUnset) '
               '? $receiver.${parameter.fieldName} '
-              ': ${parameter.name} as ${_type(parameter.typeRef)}'
+              ': $value'
         : '${parameter.name} ?? $receiver.${parameter.fieldName}';
     return parameter.kind == AckConstructorParameterKind.named
         ? '${parameter.name}: $replacement'

--- a/packages/ack_generator/lib/src/builders/data_class_emitter.dart
+++ b/packages/ack_generator/lib/src/builders/data_class_emitter.dart
@@ -75,7 +75,8 @@ mixin ${'_\$${className}Ack'} {
     final parameterList = parameters.isEmpty
         ? ''
         : '{${parameters.join(', ')}}';
-    if (castSelf) {
+    // A fieldless model reads nothing through `self`; skip the unused cast.
+    if (castSelf && arguments.isNotEmpty) {
       return '''
 $className copyWith($parameterList) {
   final self = this as $className;
@@ -96,7 +97,7 @@ $className copyWith($parameterList) => $className(${arguments.join(', ')});''';
       for (final field in fields)
         _hash('${castSelf ? 'self' : 'this'}.${field.dartName}'),
     ];
-    if (castSelf) {
+    if (castSelf && fields.isNotEmpty) {
       final fieldEquals = [
         for (final field in fields)
           _equals('self.${field.dartName}', 'other.${field.dartName}'),
@@ -139,7 +140,7 @@ int get hashCode => Object.hashAll([${hashes.join(', ')}]);''';
     required List<AckFieldNode> fields,
     bool castSelf = false,
   }) {
-    if (castSelf) {
+    if (castSelf && fields.isNotEmpty) {
       final parts = [
         for (final field in fields)
           '${field.dartName}: \${self.${field.dartName}}',

--- a/packages/ack_generator/lib/src/builders/model_emitter.dart
+++ b/packages/ack_generator/lib/src/builders/model_emitter.dart
@@ -575,10 +575,15 @@ ${_ack('AckModelAdapter')}(
     AckConstructorParameter parameter,
     AckFieldNode field,
   ) {
+    final type = _fieldType(field);
+    // Sentinel parameters are already typed Object?.
+    final value = type == 'Object?'
+        ? parameter.name
+        : '${parameter.name} as $type';
     final replacement = _fieldUsesCopyWithSentinel(field)
         ? 'identical(${parameter.name}, $_copyWithUnset) '
               '? this.${parameter.fieldName} '
-              ': ${parameter.name} as ${_fieldType(field)}'
+              ': $value'
         : '${parameter.name} ?? this.${parameter.fieldName}';
     return parameter.kind == AckConstructorParameterKind.named
         ? '${parameter.name}: $replacement'
@@ -833,7 +838,9 @@ return $helper(<String, dynamic>{
     if (!needsNullGuard) {
       body = _fromRuntime(runtimeRef, 'value');
     } else if (!_requiresRuntimeConversion(runtimeRef)) {
-      body = 'value as ${_type(runtimeRef)}?';
+      final type = '${_type(runtimeRef)}?';
+      // The bridge parameter is already Object?.
+      body = type == 'Object?' ? 'value' : 'value as $type';
     } else {
       body =
           'switch (value) {'
@@ -892,6 +899,9 @@ return $helper(<String, dynamic>{
 
   String _fromRuntime(AckInferRef type, String expression) {
     return switch (type) {
+      // Any input is already assignable to Object?; a cast would be redundant.
+      AckNullableTypeRef(inner: AckScalarTypeRef(dartType: 'Object')) =>
+        expression,
       AckNullableTypeRef(:final inner) =>
         '$expression == null ? null : ${_fromRuntime(inner, '$expression!')}',
       AckModelTypeRef(:final runtimeRef, :final visibleName) =>
@@ -908,6 +918,9 @@ return $helper(<String, dynamic>{
 
   String _toRuntime(AckInferRef type, String expression) {
     return switch (type) {
+      AckNullableTypeRef(:final inner)
+          when inner is AckScalarTypeRef || inner is AckExternalTypeRef =>
+        expression,
       AckNullableTypeRef(:final inner) =>
         '$expression == null ? null : ${_toRuntime(inner, '$expression!')}',
       AckModelTypeRef(:final visibleName) =>
@@ -924,6 +937,8 @@ return $helper(<String, dynamic>{
 
   String _immutableCopy(AckInferRef type, String expression) {
     return switch (type) {
+      AckNullableTypeRef(:final inner) when !_requiresImmutableCopy(inner) =>
+        expression,
       AckNullableTypeRef(:final inner) =>
         '$expression == null ? null : ${_immutableCopy(inner, '$expression!')}',
       AckListTypeRef(:final elementType) =>

--- a/packages/ack_generator/lib/src/builders/model_emitter.dart
+++ b/packages/ack_generator/lib/src/builders/model_emitter.dart
@@ -921,8 +921,15 @@ return $helper(<String, dynamic>{
       AckNullableTypeRef(:final inner)
           when inner is AckScalarTypeRef || inner is AckExternalTypeRef =>
         expression,
+      // `value?.map(...)` satisfies prefer_null_aware_operators.
+      AckNullableTypeRef(:final inner)
+          when inner is AckListTypeRef ||
+              inner is AckSetTypeRef ||
+              inner is AckMapTypeRef =>
+        _toRuntime(inner, '$expression?'),
+      // Expressions are promotable locals, so the null check needs no `!`.
       AckNullableTypeRef(:final inner) =>
-        '$expression == null ? null : ${_toRuntime(inner, '$expression!')}',
+        '$expression == null ? null : ${_toRuntime(inner, expression)}',
       AckModelTypeRef(:final visibleName) =>
         '$visibleName.\$ack.toRuntime($expression)',
       AckListTypeRef(:final elementType) =>
@@ -940,7 +947,7 @@ return $helper(<String, dynamic>{
       AckNullableTypeRef(:final inner) when !_requiresImmutableCopy(inner) =>
         expression,
       AckNullableTypeRef(:final inner) =>
-        '$expression == null ? null : ${_immutableCopy(inner, '$expression!')}',
+        '$expression == null ? null : ${_immutableCopy(inner, expression)}',
       AckListTypeRef(:final elementType) =>
         'List<${_type(elementType)}>.unmodifiable($expression.map((item) => ${_immutableCopy(elementType, 'item')}))',
       AckSetTypeRef(:final elementType) =>

--- a/packages/ack_generator/test/integration/ack_infer_graph_test.dart
+++ b/packages/ack_generator/test/integration/ack_infer_graph_test.dart
@@ -308,8 +308,8 @@ final valueSchema = (Ack.string().trim()).codec<String>(
     },
   );
 
-  test('rejects a local Ack.any() field by following the variable', () async {
-    await _expectFailure(
+  test('infers Object and Map fields from Ack.any() and Ack.map()', () async {
+    await _expectOutput(
       '''
 $_head
 final payloadAny = Ack.any();
@@ -317,9 +317,79 @@ final payloadAny = Ack.any();
 @AckInfer()
 final userSchema = Ack.object({
   'payload': payloadAny,
+  'kind': Ack.any(),
+  'note': Ack.any().nullable(),
+  'items': Ack.list(Ack.any()),
+  'values': Ack.map(Ack.any()),
+  'metadata': Ack.map(Ack.any().nullable()),
+  'labels': Ack.map(Ack.string()),
 });
 ''',
-      ['userSchema.payload', 'payloadAny', 'Ack.any()'],
+      allOf([
+        contains('final Object payload;'),
+        contains('final Object kind;'),
+        contains('final Object? note;'),
+        contains('final List<Object> items;'),
+        contains('final Map<String, Object> values;'),
+        contains('final Map<String, Object?> metadata;'),
+        contains('final Map<String, String> labels;'),
+        isNot(contains('value as Object?')),
+      ]),
+    );
+  });
+
+  test('rejects nullable Ack.any() list items', () async {
+    await _expectFailure(
+      '''
+$_head
+@AckInfer()
+final userSchema = Ack.object({
+  'items': Ack.list(Ack.any().nullable()),
+});
+''',
+      ['userSchema.items', 'nullable collection elements'],
+    );
+  });
+
+  test('rejects an Ack.any() root reached through a variable', () async {
+    await _expectFailure(
+      '''
+$_head
+final payloadAny = Ack.any();
+
+@AckInfer()
+final payloadSchema = payloadAny;
+''',
+      ['payloadSchema', 'Ack.any()'],
+    );
+  });
+
+  for (final source in [
+    'Ack.map(Ack.integer())',
+    'Ack.map(Ack.any().nullable()).describe("extras")',
+  ]) {
+    test('rejects Ack.map() root $source', () async {
+      await _expectFailure(
+        '''
+$_head
+@AckInfer()
+final scoresSchema = $source;
+''',
+        ['scoresSchema', 'Ack.map() root'],
+      );
+    });
+  }
+
+  test('rejects an Ack.map() root reached through a variable', () async {
+    await _expectFailure(
+      '''
+$_head
+final scoresMap = Ack.map(Ack.integer());
+
+@AckInfer()
+final scoresSchema = scoresMap;
+''',
+      ['scoresSchema', 'Ack.map() root'],
     );
   });
 

--- a/packages/ack_generator/test/integration/ack_infer_graph_test.dart
+++ b/packages/ack_generator/test/integration/ack_infer_graph_test.dart
@@ -338,6 +338,16 @@ final userSchema = Ack.object({
     );
   });
 
+  test('infers nullable map values through a nullable variable', () async {
+    await _expectOutput('''
+$_head
+final nullableAny = Ack.any().nullable();
+
+@AckInfer()
+final userSchema = Ack.object({'metadata': Ack.map(nullableAny)});
+''', contains('final Map<String, Object?> metadata;'));
+  });
+
   test('rejects nullable Ack.any() list items', () async {
     await _expectFailure(
       '''

--- a/packages/ack_generator/test/integration/ack_infer_models_test.dart
+++ b/packages/ack_generator/test/integration/ack_infer_models_test.dart
@@ -830,17 +830,19 @@ final userSchema = Ack.object({'name': Ack.string()});
     expect(messages.single, contains(r'_$UserFromJson'));
   });
 
-  test('rejects a cross-library unannotated schema variable', () async {
-    final messages = <String>{};
-    await _build(
-      {
-        'other.dart': '''
+  test(
+    'rejects an unsupported cross-library unannotated schema variable',
+    () async {
+      final messages = <String>{};
+      await _build(
+        {
+          'other.dart': '''
 import 'package:ack/ack.dart';
 
-final payloadAny = Ack.any();
+final payloadUnion = Ack.anyOf([Ack.string(), Ack.integer()]);
 ''',
-        'user.dart':
-            '''
+          'user.dart':
+              '''
 $_imports
 import 'other.dart';
 part 'user.ack.dart';
@@ -848,18 +850,52 @@ part 'user.ack.g.dart';
 
 @AckInfer()
 final userSchema = Ack.object({
-  'payload': payloadAny,
+  'payload': payloadUnion,
 });
 ''',
-      },
-      outputs: const {},
-      onLog: (log) {
-        if (log.level.name == 'SEVERE') messages.add(log.message);
-      },
-    );
-    expect(messages.single, contains('userSchema.payload'));
-    expect(messages.single, contains('payloadAny'));
-  });
+        },
+        outputs: const {},
+        onLog: (log) {
+          if (log.level.name == 'SEVERE') messages.add(log.message);
+        },
+      );
+      expect(messages.single, contains('userSchema.payload'));
+      expect(messages.single, contains('payloadUnion'));
+      expect(messages.single, contains('Ack.anyOf()'));
+    },
+  );
+
+  test(
+    'follows a cross-library Ack.any() variable to an Object field',
+    () async {
+      await _build(
+        {
+          'other.dart': '''
+import 'package:ack/ack.dart';
+
+final payloadAny = Ack.any();
+''',
+          'user.dart':
+              '''
+$_imports
+import 'other.dart';
+part 'user.ack.dart';
+part 'user.ack.g.dart';
+
+@AckInfer()
+final userSchema = Ack.object({
+  'payload': payloadAny.nullable(),
+});
+''',
+        },
+        outputs: {
+          'test_pkg|lib/user.ack.dart': decodedMatches(
+            contains('final Object? payload;'),
+          ),
+        },
+      );
+    },
+  );
 
   test('rejects a cross-library @AckInfer alias root', () async {
     final messages = <String>{};

--- a/packages/ack_generator/test/integration/ack_infer_runtime_build_test.dart
+++ b/packages/ack_generator/test/integration/ack_infer_runtime_build_test.dart
@@ -322,48 +322,49 @@ void main() {
     expect(constructed.toJson().containsKey('maybe'), isTrue);
   });
 
-  test('Ack.any and Ack.map fields hold immutable JSON values', () {
-    final json = <String, Object?>{
-      'kind': 'event',
-      'payload': {
-        'nested': [null, 1],
-      },
-      'items': [
-        1,
-        {'a': true},
-      ],
-      'values': {'a': 1},
-      'metadata': {'trace': null},
-      'labels': {'env': 'prod'},
-    };
+  final envelopeJson = <String, Object?>{
+    'kind': 'event',
+    'payload': {
+      'nested': [null, 1],
+    },
+    'items': [
+      1,
+      {'a': true},
+    ],
+    'values': {'a': 1},
+    'metadata': {'trace': null},
+    'labels': {'env': 'prod'},
+  };
 
-    final envelope = Envelope.parse(json);
+  for (final invalid in <Map<String, Object?>>[
+    {'payload': DateTime(2026)},
+    {'kind': null},
+    {
+      'values': {'a': null},
+    },
+    {
+      'labels': {'env': 1},
+    },
+  ]) {
+    test('Envelope rejects invalid field values: $invalid', () {
+      expect(Envelope.safeParse({...envelopeJson, ...invalid}).isFail, isTrue);
+    });
+  }
+
+  test('Ack.any and Ack.map fields hold immutable JSON values', () {
+    final envelope = Envelope.parse(envelopeJson);
     expect(envelope.payload, {
       'nested': [null, 1],
     });
     expect(envelope.metadata, {'trace': null});
     expect(envelope.loose, isNull);
-    expect(envelope.toJson(), json);
-    expect(Envelope.parse(json), envelope);
-    expect(Envelope.parse(json).hashCode, envelope.hashCode);
-    expect(Envelope.parse({...json, 'payload': null}).payload, isNull);
-
-    for (final invalid in <Map<String, Object?>>[
-      {'payload': DateTime(2026)},
-      {'kind': null},
-      {
-        'values': {'a': null},
-      },
-      {
-        'labels': {'env': 1},
-      },
-    ]) {
-      expect(
-        Envelope.safeParse({...json, ...invalid}).isFail,
-        isTrue,
-        reason: '$invalid',
-      );
-    }
+    expect(envelope.toJson(), envelopeJson);
+    expect(Envelope.parse(envelopeJson), envelope);
+    expect(Envelope.parse(envelopeJson).hashCode, envelope.hashCode);
+    expect(
+      Envelope.parse({...envelopeJson, 'payload': null}).payload,
+      isNull,
+    );
 
     expect(() => (envelope.payload! as Map)['x'] = 1, throwsUnsupportedError);
     expect(() => envelope.metadata['x'] = 1, throwsUnsupportedError);

--- a/packages/ack_generator/test/integration/ack_infer_runtime_build_test.dart
+++ b/packages/ack_generator/test/integration/ack_infer_runtime_build_test.dart
@@ -134,6 +134,19 @@ final emptySchema = Ack.object({});
 @AckInfer()
 final scoresSchema = Ack.list(Ack.integer());
 
+final looseAny = Ack.any();
+
+@AckInfer()
+final envelopeSchema = Ack.object({
+  'kind': Ack.any(),
+  'payload': Ack.any().nullable().optional(),
+  'items': Ack.list(Ack.any()),
+  'values': Ack.map(Ack.any()),
+  'metadata': Ack.map(Ack.any().nullable()),
+  'labels': Ack.map(Ack.string()),
+  'loose': looseAny.optional(),
+});
+
 final class Counted {
   Counted(this.value);
   final String value;
@@ -307,6 +320,68 @@ void main() {
     expect(constructed.toJson().containsKey('nickname'), isFalse);
     expect(constructed.toJson()['maybe'], isNull);
     expect(constructed.toJson().containsKey('maybe'), isTrue);
+  });
+
+  test('Ack.any and Ack.map fields hold immutable JSON values', () {
+    final json = <String, Object?>{
+      'kind': 'event',
+      'payload': {
+        'nested': [null, 1],
+      },
+      'items': [
+        1,
+        {'a': true},
+      ],
+      'values': {'a': 1},
+      'metadata': {'trace': null},
+      'labels': {'env': 'prod'},
+    };
+
+    final envelope = Envelope.parse(json);
+    expect(envelope.payload, {
+      'nested': [null, 1],
+    });
+    expect(envelope.metadata, {'trace': null});
+    expect(envelope.loose, isNull);
+    expect(envelope.toJson(), json);
+    expect(Envelope.parse(json), envelope);
+    expect(Envelope.parse(json).hashCode, envelope.hashCode);
+    expect(Envelope.parse({...json, 'payload': null}).payload, isNull);
+
+    for (final invalid in <Map<String, Object?>>[
+      {'payload': DateTime(2026)},
+      {'kind': null},
+      {
+        'values': {'a': null},
+      },
+      {
+        'labels': {'env': 1},
+      },
+    ]) {
+      expect(
+        Envelope.safeParse({...json, ...invalid}).isFail,
+        isTrue,
+        reason: '$invalid',
+      );
+    }
+
+    expect(() => (envelope.payload! as Map)['x'] = 1, throwsUnsupportedError);
+    expect(() => envelope.metadata['x'] = 1, throwsUnsupportedError);
+    expect(() => (envelope.items.last as Map)['x'] = 1, throwsUnsupportedError);
+
+    final constructed = Envelope(
+      kind: {
+        'a': [1],
+      },
+      items: const [],
+      values: const {},
+      metadata: const {},
+      labels: const {},
+    );
+    expect(Envelope.parse(constructed.toJson()), constructed);
+    expect(constructed.copyWith(payload: 'x').payload, 'x');
+    expect(constructed.copyWith(payload: 'x').copyWith(payload: null).payload,
+        isNull);
   });
 
   test('union discriminators cannot be spoofed through extras', () {

--- a/packages/ack_generator/test/integration/ack_infer_runtime_build_test.dart
+++ b/packages/ack_generator/test/integration/ack_infer_runtime_build_test.dart
@@ -53,6 +53,13 @@ dependency_overrides:
   ack_annotations:
     path: ${p.join(projectRoot.path, 'packages', 'ack_annotations')}
 ''');
+        File(p.join(temporary.path, 'analysis_options.yaml')).writeAsStringSync(
+          '''
+linter:
+  rules:
+    - prefer_null_aware_operators
+''',
+        );
         File(p.join(temporary.path, 'lib', 'models.dart')).writeAsStringSync(
           r'''
 import 'package:ack/ack.dart';
@@ -145,6 +152,14 @@ final envelopeSchema = Ack.object({
   'metadata': Ack.map(Ack.any().nullable()),
   'labels': Ack.map(Ack.string()),
   'loose': looseAny.optional(),
+});
+
+final nullableLabel = Ack.string().nullable();
+
+@AckInfer()
+final labelsSchema = Ack.object({
+  'byKey': Ack.map(nullableLabel),
+  'groups': Ack.map(Ack.list(Ack.string()).nullable()),
 });
 
 final class Counted {
@@ -383,6 +398,22 @@ void main() {
     expect(constructed.copyWith(payload: 'x').payload, 'x');
     expect(constructed.copyWith(payload: 'x').copyWith(payload: null).payload,
         isNull);
+  });
+
+  test('map values follow nullable variables and nullable collections', () {
+    final json = <String, Object?>{
+      'byKey': {'a': 'x', 'b': null},
+      'groups': {
+        'g': ['x'],
+        'none': null,
+      },
+    };
+
+    final labels = Labels.parse(json);
+
+    expect(labels.byKey, {'a': 'x', 'b': null});
+    expect(labels.groups['none'], isNull);
+    expect(labels.toJson(), json);
   });
 
   test('union discriminators cannot be spoofed through extras', () {

--- a/packages/ack_generator/test/integration/ack_type_map_schema_test.dart
+++ b/packages/ack_generator/test/integration/ack_type_map_schema_test.dart
@@ -1,0 +1,27 @@
+import 'package:ack_generator/builder.dart';
+import 'package:build/build.dart';
+import 'package:test/test.dart';
+
+import '../test_utils/generation_test_utils.dart';
+import '../test_utils/test_assets.dart';
+
+void main() {
+  // @AckType is frozen until Ack 2.0; Ack.map inference is AckInfer/AckModel
+  // only. Pin that the legacy generator fails loudly instead of guessing.
+  test('frozen @AckType rejects Ack.map fields', () async {
+    await expectGenerationFailure(
+      builder: ackGenerator(BuilderOptions.empty),
+      expectedMessage: 'Ack.map',
+      assets: {
+        ...allAssets,
+        'test_pkg|lib/config_schema.dart': '''
+import 'package:ack/ack.dart';
+import 'package:ack_annotations/ack_annotations.dart';
+
+@AckType()
+final configSchema = Ack.object({'scores': Ack.map(Ack.integer())});
+''',
+      },
+    );
+  });
+}

--- a/packages/ack_generator/test/integration/class_first_runtime_build_test.dart
+++ b/packages/ack_generator/test/integration/class_first_runtime_build_test.dart
@@ -67,6 +67,13 @@ dependency_overrides:
   ack_annotations:
     path: ${p.join(projectRoot.path, 'packages', 'ack_annotations')}
 ''');
+        File(p.join(temporary.path, 'analysis_options.yaml')).writeAsStringSync(
+          '''
+linter:
+  rules:
+    - prefer_null_aware_operators
+''',
+        );
         File(p.join(temporary.path, 'build.yaml')).writeAsStringSync('''
 targets:
   \$default:
@@ -381,6 +388,20 @@ final class Envelope with _$EnvelopeAck {
   final Map<String, String> labels;
   @AckField(schema: scoresSchema)
   final Map<String, int> scores;
+}
+
+@AckModel()
+final class Declined with _$DeclinedAck {
+  const Declined();
+}
+
+@AckModel()
+final class OptionalCollections with _$OptionalCollectionsAck {
+  const OptionalCollections({this.headers, this.aliases, this.tags});
+
+  final Map<String, String>? headers;
+  final List<String>? aliases;
+  final Set<String>? tags;
 }
 
 @AckModel(discriminatorKey: 'type')
@@ -848,6 +869,33 @@ void main() {
       throwsUnsupportedError,
     );
     expect(() => envelope.scores['b'] = 2, throwsUnsupportedError);
+  });
+
+  test('fieldless models generate working value members', () {
+    expect(DeclinedSchema.parse({}), const Declined());
+    expect(const Declined().copyWith(), const Declined());
+    expect(const Declined().hashCode, const Declined().hashCode);
+    expect(const Declined().toString(), 'Declined()');
+    expect(const Declined().toJson(), isEmpty);
+  });
+
+  test('optional collections round-trip through null-aware bridges', () {
+    final empty = OptionalCollectionsSchema.parse({});
+    expect(empty.headers, isNull);
+    expect(empty.toJson(), isEmpty);
+
+    final full = OptionalCollectionsSchema.parse({
+      'headers': {'a': 'b'},
+      'aliases': ['x'],
+      'tags': ['t'],
+    });
+    expect(full.headers, {'a': 'b'});
+    expect(full.tags, {'t'});
+    expect(full.toJson(), {
+      'headers': {'a': 'b'},
+      'aliases': ['x'],
+      'tags': ['t'],
+    });
   });
 
   test('sealed unions use super parameters and discriminator rules', () {

--- a/packages/ack_generator/test/integration/class_first_runtime_build_test.dart
+++ b/packages/ack_generator/test/integration/class_first_runtime_build_test.dart
@@ -786,34 +786,35 @@ void main() {
     );
   });
 
-  test('Object and map fields reject non-JSON and invalid values', () {
-    for (final invalid in <Map<String, Object?>>[
-      {'payload': DateTime(2026)},
-      {
-        'items': [DateTime(2026)],
+  for (final invalid in <Map<String, Object?>>[
+    {'payload': DateTime(2026)},
+    {
+      'items': [DateTime(2026)],
+    },
+    {
+      'values': {'a': null},
+    },
+    {
+      'metadata': {
+        'nested': {'at': DateTime(2026)},
       },
-      {
-        'values': {'a': null},
-      },
-      {
-        'metadata': {
-          'nested': {'at': DateTime(2026)},
-        },
-      },
-      {
-        'labels': {'env': 1},
-      },
-      {
-        'scores': {'a': -1},
-      },
-    ]) {
+    },
+    {
+      'labels': {'env': 1},
+    },
+    {
+      'scores': {'a': -1},
+    },
+  ]) {
+    test('Envelope rejects invalid field values: $invalid', () {
       expect(
         EnvelopeSchema.safeParse({...envelopeJson, ...invalid}).isFail,
         isTrue,
-        reason: '$invalid',
       );
-    }
+    });
+  }
 
+  test('Object fields reject non-JSON encodes and maps export schemas', () {
     final envelope = EnvelopeSchema.parse(envelopeJson);
     expect(
       EnvelopeSchema.safeEncode(

--- a/packages/ack_generator/test/integration/class_first_runtime_build_test.dart
+++ b/packages/ack_generator/test/integration/class_first_runtime_build_test.dart
@@ -353,6 +353,36 @@ final class CapabilityBinding with _$CapabilityBindingAck {
   static final fromJson = CapabilityBindingSchema.fromJson;
 }
 
+AckSchema<Map<String, int?>, Map<String, int?>> scoresSchema() =>
+    Ack.map(Ack.integer().min(0));
+
+@AckModel()
+final class Envelope with _$EnvelopeAck {
+  const Envelope({
+    required this.kind,
+    this.payload,
+    this.strict,
+    required this.items,
+    required this.values,
+    required this.metadata,
+    required this.labels,
+    required this.scores,
+  });
+
+  final Object kind;
+  @Optional()
+  final Object? payload;
+  @Optional()
+  @NotNull()
+  final Object? strict;
+  final List<Object> items;
+  final Map<String, Object> values;
+  final Map<String, Object?> metadata;
+  final Map<String, String> labels;
+  @AckField(schema: scoresSchema)
+  final Map<String, int> scores;
+}
+
 @AckModel(discriminatorKey: 'type')
 sealed class Pet with _$PetAck {
   const Pet({required this.id});
@@ -393,6 +423,29 @@ import 'package:ack_class_first_runtime/coexist.dart';
 import 'package:ack_class_first_runtime/models.dart';
 import 'package:ack/ack.dart';
 import 'package:test/test.dart';
+
+final envelopeJson = <String, Object?>{
+  'kind': 'event',
+  'items': [
+    1,
+    'two',
+    {
+      'three': [null, 3],
+    },
+  ],
+  'values': {
+    'a': 1,
+    'b': [true],
+  },
+  'metadata': {
+    'trace': null,
+    'nested': {
+      'x': [null, 1],
+    },
+  },
+  'labels': {'env': 'prod'},
+  'scores': {'a': 1},
+};
 
 void main() {
   test('presence, defaults, collections, and escape hatches round-trip', () {
@@ -683,6 +736,117 @@ void main() {
       'v',
     );
     expect(binding.copyWith().toJson(), {'name': 'bind', 'parameters': {}});
+  });
+
+  test('Object fields accept JSON values with String? presence rules', () {
+    final envelope = EnvelopeSchema.parse(envelopeJson);
+    expect(envelope.kind, 'event');
+    expect(envelope.payload, isNull);
+    expect(envelope.items, [
+      1,
+      'two',
+      {
+        'three': [null, 3],
+      },
+    ]);
+    expect(envelope.metadata['trace'], isNull);
+    expect(envelope.toJson(), envelopeJson);
+
+    expect(
+      EnvelopeSchema.parse({...envelopeJson, 'payload': null}).payload,
+      isNull,
+    );
+    final withPayload = EnvelopeSchema.parse({
+      ...envelopeJson,
+      'payload': {
+        'nested': [null, 1],
+      },
+    });
+    expect(withPayload.payload, {
+      'nested': [null, 1],
+    });
+    expect(withPayload.toJson()['payload'], {
+      'nested': [null, 1],
+    });
+
+    expect(EnvelopeSchema.parse({...envelopeJson, 'strict': 1}).strict, 1);
+    expect(
+      EnvelopeSchema.safeParse({...envelopeJson, 'strict': null}).isFail,
+      isTrue,
+    );
+    expect(
+      EnvelopeSchema.safeParse({...envelopeJson, 'kind': null}).isFail,
+      isTrue,
+    );
+    expect(
+      EnvelopeSchema.safeParse(
+        Map<String, Object?>.of(envelopeJson)..remove('kind'),
+      ).isFail,
+      isTrue,
+    );
+  });
+
+  test('Object and map fields reject non-JSON and invalid values', () {
+    for (final invalid in <Map<String, Object?>>[
+      {'payload': DateTime(2026)},
+      {
+        'items': [DateTime(2026)],
+      },
+      {
+        'values': {'a': null},
+      },
+      {
+        'metadata': {
+          'nested': {'at': DateTime(2026)},
+        },
+      },
+      {
+        'labels': {'env': 1},
+      },
+      {
+        'scores': {'a': -1},
+      },
+    ]) {
+      expect(
+        EnvelopeSchema.safeParse({...envelopeJson, ...invalid}).isFail,
+        isTrue,
+        reason: '$invalid',
+      );
+    }
+
+    final envelope = EnvelopeSchema.parse(envelopeJson);
+    expect(
+      EnvelopeSchema.safeEncode(
+        envelope.copyWith(payload: DateTime(2026)),
+      ).isFail,
+      isTrue,
+    );
+    expect(
+      (EnvelopeSchema.toJsonSchema()['properties']! as Map)['labels'],
+      {
+        'type': 'object',
+        'additionalProperties': {'type': 'string'},
+      },
+    );
+  });
+
+  test('parsed Object and map values are recursively unmodifiable', () {
+    final envelope = EnvelopeSchema.parse({
+      ...envelopeJson,
+      'payload': {
+        'nested': [1],
+      },
+    });
+    final payload = envelope.payload! as Map;
+    expect(() => payload['x'] = 1, throwsUnsupportedError);
+    expect(() => (payload['nested']! as List).add(2), throwsUnsupportedError);
+    expect(() => (envelope.items.last as Map)['x'] = 1, throwsUnsupportedError);
+    expect(() => envelope.metadata['x'] = 1, throwsUnsupportedError);
+    expect(
+      () => (envelope.metadata['nested']! as Map)['x'] = 1,
+      throwsUnsupportedError,
+    );
+    expect(() => envelope.scores['b'] = 2, throwsUnsupportedError);
   });
 
   test('sealed unions use super parameters and discriminator rules', () {

--- a/packages/ack_generator/test/integration/class_model_emitter_test.dart
+++ b/packages/ack_generator/test/integration/class_model_emitter_test.dart
@@ -61,6 +61,58 @@ final class Defaults with _\$DefaultsAck {
     );
   });
 
+  test('infers Ack.any and Ack.map for open JSON field types', () async {
+    await _build(
+      {
+        'envelope.dart':
+            '''
+$_imports
+part 'envelope.ack.dart';
+part 'envelope.ack.g.dart';
+
+@AckModel()
+final class Envelope with _\$EnvelopeAck {
+  const Envelope({
+    required this.kind,
+    this.payload,
+    required this.items,
+    required this.tags,
+    required this.values,
+    required this.metadata,
+    required this.labels,
+    required this.groups,
+  });
+
+  final Object kind;
+  @Optional()
+  final Object? payload;
+  final List<Object> items;
+  final Set<Object> tags;
+  final Map<String, Object> values;
+  final Map<String, Object?> metadata;
+  final Map<String, String?> labels;
+  final Map<String, List<Object>> groups;
+}
+''',
+      },
+      outputs: {
+        'test_pkg|lib/envelope.ack.dart': decodedMatches(
+          allOf([
+            contains("'kind': Ack.any()"),
+            contains("'payload': Ack.any().optional().nullable()"),
+            contains("'items': Ack.list(Ack.any())"),
+            contains("'tags': Ack.list(Ack.any()).codec<Set<Object>>"),
+            contains("'values': Ack.map(Ack.any())"),
+            contains("'metadata': Ack.map(Ack.any().nullable())"),
+            contains("'labels': Ack.map(Ack.string().nullable())"),
+            contains("'groups': Ack.map(Ack.list(Ack.any()))"),
+            isNot(contains('value as Object?')),
+          ]),
+        ),
+      },
+    );
+  });
+
   test('emits a codec schema, presence semantics, mixin, and bridges', () async {
     await _build(
       {

--- a/packages/ack_generator/test/integration/class_model_graph_test.dart
+++ b/packages/ack_generator/test/integration/class_model_graph_test.dart
@@ -214,17 +214,45 @@ final class User with _\$UserAck {
     );
   });
 
-  test('requires AckField for Map<String, V>', () async {
+  test('rejects dynamic map values and points to Object?', () async {
+    await _expectFailure(
+      '''
+@AckModel()
+final class Stats with _\$StatsAck {
+  const Stats({required this.values});
+
+  final Map<String, dynamic> values;
+}
+''',
+      ['Stats.values', 'dynamic', 'Object?'],
+    );
+  });
+
+  test('rejects nullable Object list elements', () async {
+    await _expectFailure(
+      '''
+@AckModel()
+final class Envelope with _\$EnvelopeAck {
+  const Envelope({required this.items});
+
+  final List<Object?> items;
+}
+''',
+      ['Envelope.items', 'nullable collection elements', 'Ack.list'],
+    );
+  });
+
+  test('rejects nested non-String map keys', () async {
     await _expectFailure(
       '''
 @AckModel()
 final class Stats with _\$StatsAck {
   const Stats({required this.scores});
 
-  final Map<String, int> scores;
+  final List<Map<int, String>> scores;
 }
 ''',
-      ['Stats.scores', 'Map<String, V>', '@AckField'],
+      ['Stats.scores', 'Map<String, V>', 'Map<int, String>'],
     );
   });
 
@@ -242,21 +270,19 @@ final class Stats with _\$StatsAck {
     );
   });
 
-  for (final unsupported in ['dynamic', 'Object?']) {
-    test('rejects $unsupported fields without a static contract', () async {
-      await _expectFailure(
-        '''
+  test('rejects dynamic fields and points to Object?', () async {
+    await _expectFailure(
+      '''
 @AckModel()
 final class Payload with _\$PayloadAck {
   const Payload({required this.value});
 
-  final $unsupported value;
+  final dynamic value;
 }
 ''',
-        ['Payload.value', unsupported, 'concrete type'],
-      );
-    });
-  }
+      ['Payload.value', 'dynamic', 'concrete type', 'Object?'],
+    );
+  });
 
   test('rejects private annotated classes', () async {
     await _expectFailure(


### PR DESCRIPTION
## Summary
- Adds `Ack.map(valueSchema)` / `MapSchema`: a JSON object with arbitrary string keys whose values all match one schema. Values may be `null` only when the value schema is nullable, so `Ack.map(Ack.any().nullable())` models a `JsonMap`. Errors report the key path (`#/scores/a`), value codecs decode/encode, and JSON Schema export emits `additionalProperties: <value schema>`.
- Class-first generation now infers open JSON fields from their Dart types, with no `@AckField` needed:

  | Dart field | Schema |
  | --- | --- |
  | `Object` / `Object?` | `Ack.any()` / `Ack.any().nullable()` (same presence rules as `String?`) |
  | `List<Object>`, `Set<Object>` | `Ack.list(Ack.any())` |
  | `Map<String, T>` (incl. `Map<String, Object?>`) | `Ack.map(<schema for T>)` |
  | `dynamic`, `List<Object?>`, `Map<int, V>` | still rejected (`dynamic` now suggests `Object?`) |

  `@AckField` still overrides an inferred schema.
- Schema-first accepts `Ack.any()` and `Ack.map(...)` fields (inferring `Object`/`Object?` and `Map<String, T>`). Both stay rejected as model roots, including when reached through an unannotated variable.
- `Ack.any()` parsing now returns a detached, recursively unmodifiable snapshot instead of the caller's object, matching `Ack.object()`/`Ack.list()`. This keeps parsed `Object` fields immutable without new generator helpers. Encoding still returns the runtime value unchanged.
- Generated `copyWith` no longer emits a redundant `as Object?` cast.
- Docs (LLM guide, generator README, typesafe/schemas pages, API reference, JSON Schema and converter guides, architecture) and both CHANGELOGs are updated; wording says "JSON-safe", not "any Dart value".

Closes #145

## Risk and compatibility
- **Behavior change:** code that mutates the value returned by `Ack.any().parse` will now get an `UnsupportedError`. Listed under "Changed" in the `ack` CHANGELOG.
- Values passed directly to model constructors are stored as given; only parsed values are frozen (matches existing class-first constructor behavior).
- Schema-first follows unannotated variables when inferring `Ack.map` value nullability, so `Ack.map(nullableVariable)` infers `Map<String, V?>`.
- Review follow-ups: fieldless class-first models no longer emit an unused `self` local, nullable collection bridges use null-aware access (both were `--fatal-infos` failures in consumers), and nullable class-first `Set<T>?` fields now generate compiling code.
- `Ack.map()` model roots and legacy `@AckType` support are out of scope; a test pins that `@AckType` rejects `Ack.map` fields.

## Validation
- `dart run melos run analyze` — passed (all 7 packages)
- `dart test` in `packages/ack_generator` — 320 passed (includes end-to-end build tests that run `dart analyze --fatal-infos` on generated code)
- `dart test` in `packages/ack` — 1,026 passed
- `dart test` in `example` (112), `ack_json_schema_builder` (49), `ack_mcp_dart` (63); `flutter test` in `ack_firebase_ai` (98); `dart test test` at repo root (52) — passed
- `dart run melos run validate-jsonschema` — passed
- `dart format --output=none --set-exit-if-changed .` — passed
