### PR TITLE
chore(release): prepare coordinated Ack 1.5.0 release

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -24,7 +24,7 @@ env:
   # The published release that every public API is compared against. Raise it
   # after each published version. `dart_apitool` compares the declared version
   # against the change severity, so a breaking change requires a major bump.
-  API_BASELINE_VERSION: '1.3.0'
+  API_BASELINE_VERSION: '1.4.0'
   # The lowest SDK versions that packages/*/pubspec.yaml accept.
   MINIMUM_DART_VERSION: '3.9.0'
   MINIMUM_FLUTTER_VERSION: '3.35.0'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.5.0
+
+* Add `Ack.map(valueSchema)` and `MapSchema` for string-keyed JSON objects
+  whose values share one schema; JSON Schema export emits
+  `additionalProperties: <value schema>`.
+* Infer class-first `Object`, `Object?`, `List<Object>`, and `Map<String, T>`
+  fields, and accept `Ack.any()` and `Ack.map()` schema-first fields.
+* `Ack.any()` parsing now returns a detached, recursively unmodifiable
+  snapshot. `ack_generator` requires `ack: ^1.5.0`.
+* Align all six publishable packages at 1.5.0; compare public APIs against 1.4.0.
+
 ## 1.4.0
 
 * Add `@Optional()`, `@Required()`, and `@NotNull()` class-first field

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -9,9 +9,9 @@ environment. A release-preparation PR does not publish anything.
 
 Use SemVer for the combined public API: patch for compatible fixes, minor for
 new compatible features/packages, and major when any stable public API breaks.
-The next release is **1.4.0**, adding `@Optional()`, `@Required()`, and
-`@NotNull()` plus the class-first `copyWith` fix. The runtime, Firebase,
-JSON Schema, and MCP packages have no API changes since 1.3.0.
+The next release is **1.5.0**, adding `Ack.map` / `MapSchema` and class-first
+`Object` / `Map<String, T>` field inference. The annotations, Firebase, JSON
+Schema, and MCP packages have no API changes since 1.4.0.
 
 Melos **8.7** is configured with `mode: fixed` and `workspaceTag: true`, matching
 this repository's release-tag verifier. `smartDependents: true` preserves
@@ -43,7 +43,7 @@ References: [Melos versioning](https://melos.invertase.dev/commands/version),
 3. Preview/prepare a coordinated version without creating commits or tags:
 
    ```sh
-   dart run melos version --manual-version=ack:1.4.0 --yes --no-git-commit-version
+   dart run melos version --manual-version=ack:1.5.0 --yes --no-git-commit-version
    ```
 
    Use the named flag, not a positional package argument: the positional form
@@ -56,15 +56,15 @@ References: [Melos versioning](https://melos.invertase.dev/commands/version),
    unreleased notes into the new section, preserving every published section.
    Update installation snippets to match each package's version.
 5. Set `API_BASELINE_VERSION` in `.github/workflows/preflight.yml` to the latest
-   published release (currently `1.3.0`). Record a new package's actual first
+   published release (currently `1.4.0`). Record a new package's actual first
    release in `ackPackageFirstReleases` in `scripts/src/workspace_packages.dart`;
    checks skip only older baselines. `ack_mcp_dart` first released at 1.3.0.
 6. Validate the complete release:
 
    ```sh
-   dart scripts/verify_release_tag.dart v1.4.0 --skip-ancestry
+   dart scripts/verify_release_tag.dart v1.5.0 --skip-ancestry
    dart run melos run ci
-   dart scripts/api_check.dart 1.3.0
+   dart scripts/api_check.dart 1.4.0
    dart scripts/publish_dry_run.dart
    dart run melos run validate-jsonschema:batch
    ```
@@ -115,9 +115,9 @@ After the release commit's CI/preflight succeeds and first-package setup is done
 ```sh
 git fetch origin main --tags
 # Use the exact reviewed release merge commit, not an arbitrary later main head.
-git tag -a v1.4.0 <release-merge-sha> -m 'Ack 1.4.0'
-dart scripts/verify_release_tag.dart v1.4.0
-git push origin v1.4.0
+git tag -a v1.5.0 <release-merge-sha> -m 'Ack 1.5.0'
+dart scripts/verify_release_tag.dart v1.5.0
+git push origin v1.5.0
 ```
 
 Pushing the tag triggers `.github/workflows/release.yml`; there is no Melos
@@ -143,4 +143,4 @@ or republish different contents under an existing version.
 
 After all six exact versions are visible, create the GitHub Release from the
 existing tag using the prepared release notes. Before the first subsequent code
-change, begin a new unreleased changelog section instead of editing 1.4.0 notes.
+change, begin a new unreleased changelog section instead of editing 1.5.0 notes.

--- a/packages/ack/CHANGELOG.md
+++ b/packages/ack/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.5.0
 
 ### Added
 

--- a/packages/ack/pubspec.yaml
+++ b/packages/ack/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack
 description: Schema validation and bidirectional codecs for Dart and Flutter
-version: 1.4.0
+version: 1.5.0
 repository: https://github.com/conceptadev/ack
 issue_tracker: https://github.com/conceptadev/ack/issues
 homepage: https://concepta.dev/ack

--- a/packages/ack_annotations/CHANGELOG.md
+++ b/packages/ack_annotations/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.5.0
+
+### Changed
+
+* Align with the coordinated Ack 1.5 release; this package has no runtime or
+  public API changes from 1.4.0.
+
 ## 1.4.0
 
 ### Added

--- a/packages/ack_annotations/README.md
+++ b/packages/ack_annotations/README.md
@@ -8,11 +8,11 @@ retained for Ack 1.1 extension-type compatibility.
 
 ```yaml
 dependencies:
-  ack: ^1.2.0
-  ack_annotations: ^1.4.0
+  ack: ^1.5.0
+  ack_annotations: ^1.5.0
 
 dev_dependencies:
-  ack_generator: ^1.4.0
+  ack_generator: ^1.5.0
   build_runner: ^2.4.0
 ```
 

--- a/packages/ack_annotations/pubspec.yaml
+++ b/packages/ack_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_annotations
 description: Annotations for Ack schema-first models and class-first schema generation
-version: 1.4.0
+version: 1.5.0
 repository: https://github.com/conceptadev/ack
 resolution: workspace
 topics:

--- a/packages/ack_firebase_ai/CHANGELOG.md
+++ b/packages/ack_firebase_ai/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.5.0
+
+### Changed
+
+* Align with the coordinated Ack 1.5 release; this package has no runtime or
+  public API changes from 1.4.0.
+
 ## 1.4.0
 
 ### Changed

--- a/packages/ack_firebase_ai/README.md
+++ b/packages/ack_firebase_ai/README.md
@@ -24,7 +24,7 @@ Always validate model output with the same ACK schema after generation. Firebase
 ```yaml
 dependencies:
   ack: ^1.2.0
-  ack_firebase_ai: ^1.4.0
+  ack_firebase_ai: ^1.5.0
   firebase_ai: ^3.12.2
 ```
 

--- a/packages/ack_firebase_ai/pubspec.yaml
+++ b/packages/ack_firebase_ai/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_firebase_ai
 description: Firebase AI (Gemini) schema converter for the Ack validation library
-version: 1.4.0
+version: 1.5.0
 repository: https://github.com/conceptadev/ack
 issue_tracker: https://github.com/conceptadev/ack/issues
 resolution: workspace

--- a/packages/ack_generator/CHANGELOG.md
+++ b/packages/ack_generator/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.5.0
 
 ### Added
 
@@ -13,6 +13,10 @@
 * Accept `Ack.any()` and `Ack.map(...)` schema-first fields, inferring
   `Object`/`Object?` and `Map<String, T>`. `Ack.any()` and `Ack.map()` model
   roots stay rejected, including when reached through a variable.
+
+### Changed
+
+* Require `ack: ^1.5.0`, because generated code now uses `Ack.map`.
 
 ### Fixed
 

--- a/packages/ack_generator/pubspec.yaml
+++ b/packages/ack_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_generator
 description: Generates immutable models from Ack schemas and validated schemas from Dart classes
-version: 1.4.0
+version: 1.5.0
 repository: https://github.com/conceptadev/ack
 issue_tracker: https://github.com/conceptadev/ack/issues
 resolution: workspace
@@ -28,7 +28,7 @@ dependencies:
   meta: ^1.15.0
 
   # Ack packages (versions are overridden locally by Melos)
-  ack: ^1.2.0
+  ack: ^1.5.0
   ack_annotations: ^1.4.0
 
 dev_dependencies:

--- a/packages/ack_json_schema_builder/CHANGELOG.md
+++ b/packages/ack_json_schema_builder/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.5.0
+
+### Changed
+
+* Align with the coordinated Ack 1.5 release; this package has no runtime or
+  public API changes from 1.4.0.
+
 ## 1.4.0
 
 ### Changed

--- a/packages/ack_json_schema_builder/README.md
+++ b/packages/ack_json_schema_builder/README.md
@@ -13,7 +13,7 @@ Converts ACK schemas to json_schema_builder format via `.toJsonSchemaBuilder()`.
 ```yaml
 dependencies:
   ack: ^1.2.0
-  ack_json_schema_builder: ^1.4.0
+  ack_json_schema_builder: ^1.5.0
   json_schema_builder: ^0.1.3
 ```
 

--- a/packages/ack_json_schema_builder/pubspec.yaml
+++ b/packages/ack_json_schema_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_json_schema_builder
 description: JSON Schema Builder converter for the Ack validation library
-version: 1.4.0
+version: 1.5.0
 repository: https://github.com/conceptadev/ack
 issue_tracker: https://github.com/conceptadev/ack/issues
 resolution: workspace

--- a/packages/ack_mcp_dart/CHANGELOG.md
+++ b/packages/ack_mcp_dart/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.5.0
+
+### Changed
+
+* Align with the coordinated Ack 1.5 release; this package has no runtime or
+  public API changes from 1.4.0.
+
 ## 1.4.0
 
 ### Changed

--- a/packages/ack_mcp_dart/README.md
+++ b/packages/ack_mcp_dart/README.md
@@ -16,7 +16,7 @@ Transport, negotiation, cancellation, and lifecycle remain in `mcp_dart`.
 ```yaml
 dependencies:
   ack: ^1.2.0
-  ack_mcp_dart: ^1.4.0
+  ack_mcp_dart: ^1.5.0
   mcp_dart: ^2.4.2
 ```
 

--- a/packages/ack_mcp_dart/example/example.dart
+++ b/packages/ack_mcp_dart/example/example.dart
@@ -18,7 +18,7 @@ final searchInput = Ack.object({
 
 Future<void> main() async {
   final server = McpServer(
-    const Implementation(name: 'ack-search-example', version: '1.4.0'),
+    const Implementation(name: 'ack-search-example', version: '1.5.0'),
   );
   server.registerAckTool(
     'search',

--- a/packages/ack_mcp_dart/pubspec.yaml
+++ b/packages/ack_mcp_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ack_mcp_dart
 description: MCP tool schemas and typed argument validation for Ack and mcp_dart
-version: 1.4.0
+version: 1.5.0
 repository: https://github.com/conceptadev/ack
 issue_tracker: https://github.com/conceptadev/ack/issues
 resolution: workspace


### PR DESCRIPTION
## Summary
- Prepares the coordinated **Ack 1.5.0** release for all six publishable packages (minor bump: `ack` adds `Ack.map` / `MapSchema`, and `ack_generator` adds `Object` / `Map<String, T>` inference from #146).
- Raises `ack_generator`'s dependency to `ack: ^1.5.0` because generated code now calls `Ack.map`; `ack_annotations: ^1.4.0` is unchanged.
- Curates the root and package CHANGELOGs in the 1.4.0 style (lockstep packages note no API changes since 1.4.0), bumps install snippets and the MCP example version, and moves `API_BASELINE_VERSION` and PUBLISHING.md to the 1.4.0 baseline / 1.5.0 release.

Follows #146 (merged into `main` as 2e542b48). Publishing happens only after this merges and `v1.5.0` is tagged on the release merge commit (see PUBLISHING.md).

## Validation
- `dart scripts/verify_release_tag.dart v1.5.0 --skip-ancestry` — v1.5.0 is releasable
- `dart scripts/api_check.dart 1.4.0` — no breaking changes; `ack` adds `MapSchema` and `Ack.map` (minor)
- `dart scripts/publish_dry_run.dart` — 0 warnings for all six packages
- `dart run melos run validate-jsonschema:batch` — 78/78 schemas valid
- `dart run melos run ci` — passed
